### PR TITLE
Add dynamically inserted ad to article body

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -100,6 +100,7 @@
       </div>
       <v-spacer size="quad" />
       <v-streamfield
+        ref="article-body"
         class="l-container l-container--10col article-body c-article__body"
         :streamfield="article.body"
       />
@@ -178,6 +179,7 @@
 <script>
 import gtm from '@/mixins/gtm'
 import { getImagePath } from '~/mixins/image'
+import insertAdDiv from '~/utils/insert-ad-div'
 
 const {
   handleScroll
@@ -506,6 +508,11 @@ export default {
   beforeDestroy () {
     window.removeEventListener('scroll', this.scrollListener)
   },
+  updated () {
+    if (this.$refs['article-body']) {
+      insertAdDiv('insertedAd', this.$refs['article-body'].$el, { classNames: ['htlad-interior_midpage_1'] })
+    }
+  },
   methods: {
     articleGaEvent () {
       this.gaArticleEvent('NTG article milestone', this.gtmData.milestone + '%', this.gtmData.articleTitle, this.gtmData)
@@ -627,4 +634,19 @@ export default {
 .article-read-more-in {
   margin-bottom: var(--space-6);
 }
+
+#insertedAd > div > div > div::after {
+    content: "Advertisement";
+    display: block;
+    color: RGB(var(--color-text-muted));
+    font-family: var(--font-family-small);
+    letter-spacing: var(--letter-spacing-small);
+    font-weight: var(--font-weight-small);
+    font-size: var(--font-size-1);
+    line-height: var(--line-height-1);
+    margin-top: var(--space-2);
+    text-transform: uppercase;
+    text-align: right;
+}
+
 </style>

--- a/utils/insert-ad-div.js
+++ b/utils/insert-ad-div.js
@@ -1,0 +1,126 @@
+const INLINE_TAGS = ['a', 'b', 'i', 'em', 'strong']
+const HEADER_TAGS = ['h1', 'h2', 'h3', 'h4', 'h5']
+const EMBED_TAGS = ['iframe', 'embed', 'video',
+  'twitter-widget', 'center', 'div']
+// a `div` tag in MT article markup is probably from an embed
+const EMBED_WEIGHT = 50
+
+// Rules for where to avoid inserting ads
+const DONT_INSERT_BEFORE = ['blockquote', ...INLINE_TAGS]
+const DONT_INSERT_AFTER = [...HEADER_TAGS, ...INLINE_TAGS]
+const DONT_INSERT_BETWEEN = EMBED_TAGS.map(embed => ['p', embed])
+function _shouldntInsertBetween (current, next) {
+  return DONT_INSERT_BETWEEN
+    .some(([first, second]) => current === first && next === second)
+}
+function _canInsertHere (current, next) {
+  return !DONT_INSERT_AFTER.includes(current) &&
+  !DONT_INSERT_BEFORE.includes(next) &&
+  !_shouldntInsertBetween(current, next)
+}
+
+// Word count helpers
+function _countWords (node) {
+  const text = node.textContent
+  return text.replace(/[^\w ]/g, '').split(/\s+/).length
+}
+function _getWordWeight (node) {
+  const tagType = node.nodeName.toLowerCase()
+  let wordWeight = _countWords(node)
+  if (EMBED_TAGS.includes(tagType)) {
+    wordWeight = Math.max(wordWeight, EMBED_WEIGHT)
+  }
+  return wordWeight
+}
+
+// return false for whitespace only text and P nodes.
+function _isNotWhitespaceOnly (node) {
+  return !(['#text', 'P'].includes(node.nodeName) &&
+  node.textContent.replace(/\s/g, '').length === 0)
+}
+
+// Insert next to insertLocation, or append the end.
+function _insertAtLocation (element, container, insertLocation) {
+  if (insertLocation && insertLocation.nextSibling) {
+    container.insertBefore(element, insertLocation.nextSibling)
+  } else {
+    container.appendChild(element)
+  }
+}
+
+function _unwrapElement (element) {
+  const parent = element.parentNode
+
+  // Move all children node to the parent
+  while (element.firstChild) {
+    element.firstChild.classList?.add('streamfield-block')
+    parent.insertBefore(element.firstChild, element)
+  }
+
+  // `element` becomes an empty element
+  // Remove it from the parent
+  parent.removeChild(element)
+}
+
+let target
+
+/**
+  Inserts a div into a story's DOM based on the following rules.
+
+  For each top level child node of `container`, count the words
+  (embeds count as at least 50 words).  When the total word count
+  exceeds the value of `wordsBeforeAd`, insert the div right after that node, unless...
+
+  Unless one of the dontInsertBefore, dontInsertAfter,
+  dontInsertBetween, rules applies. Then continue to the
+  next node and try again.
+
+  If all else fails, insert the div at the very end.
+
+  @function insertAdDiv
+  @param divId {String} An id to apply to the inserted div
+  @param container {Element} The top level element to insert the
+  ad into
+  @param options {Object}
+  @param options.wordsBeforeAd {number}  The minimum number of words
+  before inserting the div
+  @param options.classNames {string[]}  A list of classes to apply
+  to the inserted Div
+  @return {Element} The inserted div
+*/
+const insertAdDiv = function (divId, container, { wordsBeforeAd = 150, classNames = [] } = {}) {
+  // remove the wrapper elements so paragraphs are top level elements
+  container.childNodes.forEach((element) => {
+    if (element.classList?.contains('streamfield-paragraph') || // article text
+        element.classList?.contains('streamfield-code')) { // legacy articles are just html in code blocks
+      _unwrapElement(element)
+    }
+  })
+
+  const nodes = [...container.childNodes].filter(_isNotWhitespaceOnly)
+  let wordCount = 0
+
+  // Loop through nodes, return the first valid insert location
+  const insertLocation = nodes.find((node, index) => {
+    const currentTag = node.nodeName.toLowerCase()
+    const nextTag = nodes[index + 1] && nodes[index + 1].nodeName.toLowerCase()
+
+    // Increment the word count
+    wordCount = wordCount += _getWordWeight(node)
+
+    // Check if this is a valid insert location
+    if (wordCount >= wordsBeforeAd && _canInsertHere(currentTag, nextTag)) {
+      return node
+    }
+  })
+  // Create the target div (or reuse it)
+  target = target || document.createElement('div')
+  target.id = divId
+  target.className = ''
+  target.classList.add(...classNames)
+
+  _insertAtLocation(target, container, insertLocation)
+  return target
+}
+
+export default insertAdDiv


### PR DESCRIPTION
Uses the inserted ad code from the ember client. Some modifications were made because it's not easy in vue to render an html block from the CMS without a wrapper element, so were removing it afterwards so it works with this code. Code could potentially be rewritten to not need this but i didn't want to mess with it too much for now.

Known issues
- no tests, there are tests in the ember client that could be ported over once we got testing set up in this repo
- No handling for ads wider than the article yet