### PR TITLE
tweaks to the header to better handle overlay ads

### DIFF
--- a/components/GothamistHeader.vue
+++ b/components/GothamistHeader.vue
@@ -301,13 +301,15 @@ export default {
   position: absolute;
   width: 110px;
   height: 115px;
-  top: -5px;
-  left: 40px;
+  top: -11px;
+  left: 66px;
   @include media(">medium") {
     width: 135px;
     height: 142px;
     top: -30px;
-    left: calc(50% - var(--xl-container) / 2 + var(--space-5));
+  }
+  @include media(">1255px") {
+    left: calc((100vw - var(--max-width-xl)) / 2);
   }
 }
 

--- a/components/GothamistHeader.vue
+++ b/components/GothamistHeader.vue
@@ -297,8 +297,7 @@ export default {
   }
 }
 
-.home-page .gothamist-header:not(.is-stuck) .c-main-header__logo,
-.home-page .gothamist-header .gothamist-logo-icon--stacked {
+.home-page .gothamist-header:not(.is-stuck) .c-main-header__logo{
   position: absolute;
   width: 110px;
   height: 115px;
@@ -307,9 +306,14 @@ export default {
   @include media(">medium") {
     width: 135px;
     height: 142px;
-    top: -15px;
-    margin-left: calc(50% - var(--xl-container) / 2 + var(--space-5));
+    top: -30px;
+    left: calc(50% - var(--xl-container) / 2 + var(--space-5));
   }
+}
+
+.home-page .gothamist-header .gothamist-logo-icon--stacked {
+  width: 100%;
+  height: 100%;
 }
 
 .home-page .c-main-header__logo .gothamist-logo-icon--stacked .gothamist-letters path {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -117,6 +117,7 @@ html {
 }
 
 .ad-wrapper-outer.mod-header {
+  position: relative;
   background: RGB(var(--color-background));
   width: 100%;
 }


### PR DESCRIPTION
- add positioning to the top banner so it can cover the overlay
- position the hanging logo so it always remains between the main sections margins and doesn't stick out into the overlay zone