### PR TITLE
Hide ads on the article page when the article's sensitive content flag is set

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -126,7 +126,7 @@
         />
       </div>
 
-      <div class="ad-wrapper-outer">
+      <div v-if="!article.sensitiveContent" class="ad-wrapper-outer">
         <div class="ad-wrapper-inner">
           <div class="htlad-interior_midpage_2" />
           <div class="ad-label">
@@ -496,6 +496,23 @@ export default {
         this.gtmData.milestone = 100
         this.articleGaEvent()
       }
+    },
+    article () {
+      if (this.article && this.article.sensitiveContent) {
+        this.$store.commit('global/setSensitiveContent', true)
+      } else {
+        this.$store.commit('global/setSensitiveContent', false)
+      }
+      if (this.article && this.$refs['article-body'] && !this.article.sensitiveContent) {
+        insertAdDiv('insertedAd', this.$refs['article-body'].$el, { classNames: ['htlad-interior_midpage_1'] })
+      }
+    }
+  },
+  created () {
+    if (this.article && this.article.sensitiveContent) {
+      this.$store.commit('global/setSensitiveContent', true)
+    } else {
+      this.$store.commit('global/setSensitiveContent', false)
     }
   },
   mounted () {
@@ -507,11 +524,7 @@ export default {
   },
   beforeDestroy () {
     window.removeEventListener('scroll', this.scrollListener)
-  },
-  updated () {
-    if (this.$refs['article-body']) {
-      insertAdDiv('insertedAd', this.$refs['article-body'].$el, { classNames: ['htlad-interior_midpage_1'] })
-    }
+    this.$store.commit('global/setSensitiveContent', false)
   },
   methods: {
     articleGaEvent () {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="{'home-page' : isHomepage}">
-    <div class="htlad-skin" />
+    <div v-if="!isSensitiveContent" class="htlad-skin" />
     <div v-if="!isSensitiveContent" class="ad-wrapper-outer mod-header u-color-group-dark">
       <div class="ad-wrapper-inner">
         <div v-if="isHomepage" key="index-leaderboard" class="htlad-index_leaderboard_1" />

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="{'home-page' : isHomepage}">
     <div class="htlad-skin" />
-    <div class="ad-wrapper-outer mod-header u-color-group-dark">
+    <div v-if="!isSensitiveContent" class="ad-wrapper-outer mod-header u-color-group-dark">
       <div class="ad-wrapper-inner">
         <div v-if="isHomepage" key="index-leaderboard" class="htlad-index_leaderboard_1" />
         <div v-else key="interior-leaderboard" class="htlad-interior_leaderboard" />
@@ -53,6 +53,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
 export default {
   name: 'Gothamist',
   components: {
@@ -71,7 +72,8 @@ export default {
   computed: {
     isHomepage () {
       return this.$route.name === 'index'
-    }
+    },
+    ...mapState('global', ['isSensitiveContent'])
   },
   async mounted () {
     // htlbid

--- a/store/global.js
+++ b/store/global.js
@@ -36,6 +36,7 @@ export const state = () => ({
       url: '/election-2021'
     }
   ],
+  isSensitiveContent: false,
   tipsEmail: 'tips@gothamist.com',
   wtcNewsletter: '8c376c6dff'
 })
@@ -138,5 +139,8 @@ export const mutations = {
   },
   setPreviousPath (state, path) {
     state.previousPath = path
+  },
+  setSensitiveContent (state, value) {
+    state.isSensitiveContent = value
   }
 }


### PR DESCRIPTION
We don't control the ads directly so the goal is to hide the ad divs as soon as possible so the htl script doesn't see them and make any requests to ad networks.

I have to make this work on the default template as well (header ads), which doesn't have access to the article properties so I'm using a variable in the vuex store.