### PR TITLE
Ad fixes

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -503,9 +503,6 @@ export default {
       } else {
         this.$store.commit('global/setSensitiveContent', false)
       }
-      if (this.article && this.$refs['article-body'] && !this.article.sensitiveContent) {
-        insertAdDiv('insertedAd', this.$refs['article-body'].$el, { classNames: ['htlad-interior_midpage_1'] })
-      }
     }
   },
   created () {
@@ -513,6 +510,11 @@ export default {
       this.$store.commit('global/setSensitiveContent', true)
     } else {
       this.$store.commit('global/setSensitiveContent', false)
+    }
+  },
+  updated () {
+    if (this.article && this.$refs['article-body'] && !this.article.sensitiveContent) {
+      insertAdDiv('insertedAd', this.$refs['article-body'].$el, { classNames: ['htlad-interior_midpage_1'] })
     }
   },
   mounted () {

--- a/mixins/gtm.js
+++ b/mixins/gtm.js
@@ -63,7 +63,7 @@ export default {
         hitType = 'exception'
       }
       const data = {
-        event: 'Page View',
+        event: 'Article Event',
         sessionID: this.sessionID,
         previousPath: this.previousPath,
         IDCustomEvents: this.clientID,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -188,14 +188,16 @@
         </div>
         <v-spacer />
       </div>
-      <div class="ad-wrapper-outer">
-        <div class="ad-wrapper-inner">
-          <div class="htlad-index_leaderboard_2" />
-          <div class="ad-label">
-            Advertisement
+      <mq-layout mq="medium+">
+        <div class="ad-wrapper-outer">
+          <div class="ad-wrapper-inner">
+            <div class="htlad-index_leaderboard_2" />
+            <div class="ad-label">
+              Advertisement
+            </div>
           </div>
         </div>
-      </div>
+      </mq-layout>
       <!-- section 2 -->
       <div class="l-container l-container--10col l-wrap">
         <v-spacer size="triple" />


### PR DESCRIPTION
- Fix ad insertion  by moving the trigger back to the updated hook. watch:article didn't seem to be triggering it at the right time.  The code reuses an existing DIV if it finds one so running it more times than strictly necessary should be a big issue.
- Add conditional responsive rendering to the index_leaderboard_2 ad unit, looks like this is how we did it on the old site.
- Changed the name of article events so they don't activate the GTM Custom Event 'Page View' trigger. I think this is what's causing the ad refresh. (We do want it to run when navigating between pages so i'm only changing it for the article events.)