### PR TITLE
gtm fixes for article events

### DIFF
--- a/mixins/gtm.js
+++ b/mixins/gtm.js
@@ -63,7 +63,7 @@ export default {
         hitType = 'exception'
       }
       const data = {
-        event: 'Article Event',
+        event: 'eventTracking',
         sessionID: this.sessionID,
         previousPath: this.previousPath,
         IDCustomEvents: this.clientID,


### PR DESCRIPTION
realized after merging that the event name for these events should probably be set specifically to 'articleEvent' so that GTM can still do something with them. Not sure if this is all that's needed to retain all the custom dimension data etc, but we can't handle these as page views.