### PR TITLE
Don't inline css into the ssr response

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -205,6 +205,7 @@ export default {
     transpile: [
       'nypr-design-system-vue'
     ],
+    extractCSS: true,
     extend (config, ctx) {
       config.module.rules.push({
         resolve: { symlinks: false }


### PR DESCRIPTION
Twitter card preview was complaining about the page being too large to index. I think the main reason for this is the inlined css in the prerendered SSR response.

The good news: Based on testing on squash, this reduces the size of the prerendered template by a lot by moving the css into external files and allows twitter cards to work. Pages still looks the same.
The other news: I have absolutely no idea how this change impacts overall page performance.