### PR TITLE
fix for social titles

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -354,12 +354,12 @@ export default {
         {
           hid: 'og_description',
           property: 'og:description',
-          content: this.article.socialText ?? this.article.description
+          content: this.article.socialText || this.article.description
         },
         {
           hid: 'og_title',
           property: 'og:title',
-          content: this.article.socialTitle ?? this.article.title
+          content: this.article.socialTitle || this.article.title
         },
         {
           hid: 'og_type',


### PR DESCRIPTION
These fields actually come from the CMS as empty strings and not null values so we want to use the more lenient OR operator here to ignore the empty strings