### PR TITLE
Don't add history entries when updating the gallery image parameter

### DIFF
--- a/pages/_section/photos/_gallery.vue
+++ b/pages/_section/photos/_gallery.vue
@@ -165,7 +165,7 @@ export default {
     },
     visibilityChanged (isVisible, entry, imageId) {
       if (isVisible && this.pageLoaded) {
-        this.$router.push({
+        this.$router.replace({
           path: this.$route.path,
           query: { image: imageId }
         })


### PR DESCRIPTION
This is a fix for browser back button navigation when visiting the gallery page
https://jira.wnyc.org/browse/GOTH-153