### PR TITLE
Move gothamist style div to higher level, update insert ad div code f…

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -509,6 +509,9 @@ export default {
     }
   },
   async mounted () {
+    if (this.article && this.$refs['article-body'] && !this.article.sensitiveContent) {
+      insertAdDiv('insertedAd', this.$refs['article-body'].$el, { classNames: ['htlad-interior_midpage_1', 'ad-div', 'mod-break-margins', 'mod-ad-disclosure'] })
+    }
     this.scrollPercent25Logged = false
     this.scrollPercent50Logged = false
     this.scrollPercent75Logged = false

--- a/components/Article.vue
+++ b/components/Article.vue
@@ -100,9 +100,11 @@
       </div>
       <v-spacer size="quad" />
       <v-streamfield
+        :key="article.uuid || article.legacyId"
         ref="article-body"
         class="l-container l-container--10col article-body c-article__body"
         :streamfield="article.body"
+        @hook:mounted="insertAd"
       />
       <v-spacer size="quad" />
       <div
@@ -503,15 +505,7 @@ export default {
       }
     }
   },
-  updated () {
-    if (this.article && this.$refs['article-body'] && !this.article.sensitiveContent) {
-      insertAdDiv('insertedAd', this.$refs['article-body'].$el, { classNames: ['htlad-interior_midpage_1', 'ad-div', 'mod-break-margins', 'mod-ad-disclosure'] })
-    }
-  },
   async mounted () {
-    if (this.article && this.$refs['article-body'] && !this.article.sensitiveContent) {
-      insertAdDiv('insertedAd', this.$refs['article-body'].$el, { classNames: ['htlad-interior_midpage_1', 'ad-div', 'mod-break-margins', 'mod-ad-disclosure'] })
-    }
     this.scrollPercent25Logged = false
     this.scrollPercent50Logged = false
     this.scrollPercent75Logged = false
@@ -552,6 +546,11 @@ export default {
     },
     scrollToComments () {
       document.querySelector('#comments')?.scrollIntoView()
+    },
+    insertAd () {
+      if (this.article && this.$refs['article-body'] && !this.article.sensitiveContent) {
+        insertAdDiv('insertedAd', this.$refs['article-body'].$el, { classNames: ['htlad-interior_midpage_1', 'ad-div', 'mod-break-margins', 'mod-ad-disclosure'], reset: true })
+      }
     }
   },
   head () {

--- a/components/VStreamfield.vue
+++ b/components/VStreamfield.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="streamfield">
+  <div class="streamfield o-rte-text">
     <template v-for="block in streamfield">
       <!-- block-quote -->
       <div v-if="block.type === 'block-quote'" :key="block.id" class="streamfield-block-quote">
@@ -14,7 +14,7 @@
       <div
         v-else-if="block.type === 'code'"
         :key="block.id"
-        class="streamfield-code o-rte-text u-spacing"
+        class="streamfield-code u-spacing"
         v-html="block.value.code"
       />
 
@@ -85,7 +85,7 @@
       <div
         v-else-if="block.type === 'paragraph'"
         :key="block.id"
-        class="streamfield-paragraph o-rte-text u-spacing"
+        class="streamfield-paragraph u-spacing"
         v-html="block.value"
       />
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -118,6 +118,9 @@ export default {
       document.querySelectorAll('.htlunit-interior_leaderboard').forEach(function (el) {
         el.remove()
       })
+      document.querySelectorAll('.htlunit-interior_midpage_1').forEach(function (el) {
+        el.remove()
+      })
       // htlbid key value targeting for ads
       const htlbid = window.htlbid = window.htlbid || {}
       htlbid.cmd = htlbid.cmd || []

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -118,9 +118,6 @@ export default {
       document.querySelectorAll('.htlunit-interior_leaderboard').forEach(function (el) {
         el.remove()
       })
-      document.querySelectorAll('.htlunit-interior_midpage_1').forEach(function (el) {
-        el.remove()
-      })
       // htlbid key value targeting for ads
       const htlbid = window.htlbid = window.htlbid || {}
       htlbid.cmd = htlbid.cmd || []

--- a/utils/insert-ad-div.js
+++ b/utils/insert-ad-div.js
@@ -88,7 +88,7 @@ let target
   to the inserted Div
   @return {Element} The inserted div
 */
-const insertAdDiv = function (divId, container, { wordsBeforeAd = 150, classNames = [] } = {}) {
+const insertAdDiv = function (divId, container, { wordsBeforeAd = 150, classNames = [], reset = false } = {}) {
   // remove the wrapper elements so paragraphs are top level elements
   container.childNodes.forEach((element) => {
     if (element.classList?.contains('streamfield-paragraph') || // article text
@@ -114,7 +114,11 @@ const insertAdDiv = function (divId, container, { wordsBeforeAd = 150, className
     }
   })
   // Create the target div (or reuse it)
-  target = target || document.createElement('div')
+  if (reset) {
+    target = document.createElement('div')
+  } else {
+    target = target || document.createElement('div')
+  }
   target.id = divId
   target.className = ''
   target.classList.add(...classNames)


### PR DESCRIPTION
the ad div insertion code removes the wrappers from streamfield paragraph and code divs (for ease of looping through their children and because it saves us from refactoring the old code where they were never in a wrapper). These wrappers had a class that we need to load article styles including, list styles, which were missing. That class (`o-rte-text`) is now on the parent of the whole streamfield, so these styles should be applied again.

Additionally, the inserted ad code wasn't always being run, particularly when coming to a page straight from a url. Now it should always run.

The new ad insertion method seems much more reliable so far.
: add a key to the streamfield object so it always gets re-rendered and doesn't reuse the dom, preventing weird multiple ad issues
2: run the ad code on the mounted hook for the streamfield instead of the article component. With the key changes this always runs even when switching from one article route to another.