### PR TITLE
Alway unwrap the components, even when not inserting ads

### DIFF
--- a/components/Article.vue
+++ b/components/Article.vue
@@ -175,7 +175,7 @@
 import gtm from '@/mixins/gtm'
 import disqus from '@/mixins/disqus'
 import { getImagePath } from '~/mixins/image'
-import insertAdDiv from '~/utils/insert-ad-div'
+import { insertAdDiv, unwrapText } from '~/utils/insert-ad-div'
 
 const {
   handleScroll
@@ -548,6 +548,7 @@ export default {
       document.querySelector('#comments')?.scrollIntoView()
     },
     insertAd () {
+      unwrapText(this.$refs['article-body'].$el)
       if (this.article && this.$refs['article-body'] && !this.article.sensitiveContent) {
         insertAdDiv('insertedAd', this.$refs['article-body'].$el, { classNames: ['htlad-interior_midpage_1', 'ad-div', 'mod-break-margins', 'mod-ad-disclosure'], reset: true })
       }

--- a/utils/insert-ad-div.js
+++ b/utils/insert-ad-div.js
@@ -64,6 +64,16 @@ function _unwrapElement (element) {
 
 let target
 
+// remove the wrapper elements so paragraphs are top level elements
+const unwrapText = function (container) {
+  container.childNodes.forEach((element) => {
+    if (element.classList?.contains('streamfield-paragraph') || // article text
+        element.classList?.contains('streamfield-code')) { // legacy articles are just html in code blocks
+      _unwrapElement(element)
+    }
+  })
+}
+
 /**
   Inserts a div into a story's DOM based on the following rules.
 
@@ -89,14 +99,6 @@ let target
   @return {Element} The inserted div
 */
 const insertAdDiv = function (divId, container, { wordsBeforeAd = 150, classNames = [], reset = false } = {}) {
-  // remove the wrapper elements so paragraphs are top level elements
-  container.childNodes.forEach((element) => {
-    if (element.classList?.contains('streamfield-paragraph') || // article text
-        element.classList?.contains('streamfield-code')) { // legacy articles are just html in code blocks
-      _unwrapElement(element)
-    }
-  })
-
   const nodes = [...container.childNodes].filter(_isNotWhitespaceOnly)
   let wordCount = 0
 
@@ -128,3 +130,7 @@ const insertAdDiv = function (divId, container, { wordsBeforeAd = 150, className
 }
 
 export default insertAdDiv
+export {
+  insertAdDiv,
+  unwrapText
+}


### PR DESCRIPTION
This should be a separate step so styles are consistent even when we don't insert ads (e.g. on articles flagged as sensitive content)