### PR TITLE
product banner breaking news fix

### DIFF
--- a/components/GothamistBreakingNews.vue
+++ b/components/GothamistBreakingNews.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="gothamist-breaking-news">
+  <div v-if="breakingNewsBanner.length > 0" class="gothamist-breaking-news">
     <template
       v-for="(banner, index) in breakingNewsBanner"
       class="l-container l-container--xl l-wrap"
@@ -7,6 +7,7 @@
       <v-banner
         v-if="banner.value"
         :key="index"
+        class="gothamist-breaking-news-banner"
         tag="Breaking News"
         :headline="banner.value.title"
         :headline-link="banner.value.link"

--- a/components/GothamistBreakingNews.vue
+++ b/components/GothamistBreakingNews.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="breakingNewsBanner.length > 0" class="gothamist-breaking-news">
+  <div v-if="breakingNewsBanner && breakingNewsBanner.length > 0" class="gothamist-breaking-news">
     <template
       v-for="(banner, index) in breakingNewsBanner"
       class="l-container l-container--xl l-wrap"
@@ -36,3 +36,8 @@ export default {
   }
 }
 </script>
+<style>
+.gothamist-breaking-news-banner {
+   margin-bottom: var(--space-3);
+}
+</style>

--- a/components/GothamistBreakingNews.vue
+++ b/components/GothamistBreakingNews.vue
@@ -23,11 +23,9 @@ export default {
     VBanner: () => import('nypr-design-system-vue/src/components/VBanner')
   },
   async fetch () {
-    await this.$axios
+    this.breakingNewsBanner = await this.$axios
       .get(`/sitewide_components/${this.$config.siteId}/`)
-      .then(response => (
-        this.breakingNewsBanner = response.data.breakingNews
-      ))
+      .then(response => response.data.breakingNews)
   },
   data () {
     return {

--- a/components/GothamistBreakingNews.vue
+++ b/components/GothamistBreakingNews.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="gothamist-breaking-news">
+    <template
+      v-for="(banner, index) in breakingNewsBanner"
+      class="l-container l-container--xl l-wrap"
+    >
+      <v-banner
+        v-if="banner.value"
+        :key="index"
+        tag="Breaking News"
+        :headline="banner.value.title"
+        :headline-link="banner.value.link"
+        :description="banner.value.description"
+      />
+    </template>
+  </div>
+</template>
+
+<script>
+export default {
+  components: {
+    VBanner: () => import('nypr-design-system-vue/src/components/VBanner')
+  },
+  async fetch () {
+    await this.$axios
+      .get(`/sitewide_components/${this.$config.siteId}/`)
+      .then(response => (
+        this.breakingNewsBanner = response.data.breakingNews
+      ))
+  },
+  data () {
+    return {
+      breakingNewsBanner: null
+    }
+  }
+}
+</script>

--- a/components/GothamistMarketingBanners.vue
+++ b/components/GothamistMarketingBanners.vue
@@ -23,11 +23,9 @@ export default {
     ProductMarketingBanner: () => import('../components/ProductMarketingBanner')
   },
   async fetch () {
-    await this.$axios
+    this.productMarketingBanner = await this.$axios
       .get('/system_messages/1/')
-      .then(response => (
-        this.productMarketingBanner = response.data.productBanners
-      ))
+      .then(response => response.data.productBanners)
   },
   data () {
     return {

--- a/components/GothamistMarketingBanners.vue
+++ b/components/GothamistMarketingBanners.vue
@@ -1,0 +1,43 @@
+<template>
+  <div v-if="productMarketingBanner && productMarketingBanner.length > 0" class="gothamist-marketing-banners">
+    <template
+      v-for="(banner, index) in productMarketingBanner"
+      class="l-container l-container--xl l-wrap"
+    >
+      <product-marketing-banner
+        v-if="banner.value"
+        :key="index"
+        class="gothamist-marketing-banners-banner"
+        :title="banner.value.title"
+        :description="banner.value.description"
+        :cta="banner.value.buttonText"
+        :link="banner.value.buttonLink"
+      />
+    </template>
+  </div>
+</template>
+
+<script>
+export default {
+  components: {
+    ProductMarketingBanner: () => import('../components/ProductMarketingBanner')
+  },
+  async fetch () {
+    await this.$axios
+      .get('/system_messages/1/')
+      .then(response => (
+        this.productMarketingBanner = response.data.productBanners
+      ))
+  },
+  data () {
+    return {
+      productMarketingBanner: null
+    }
+  }
+}
+</script>
+<style>
+.gothamist-marketing-banners-banner {
+   margin-bottom: var(--space-5);
+}
+</style>

--- a/components/GothamistMarketingBanners.vue
+++ b/components/GothamistMarketingBanners.vue
@@ -38,6 +38,6 @@ export default {
 </script>
 <style>
 .gothamist-marketing-banners-banner {
-   margin-bottom: var(--space-5);
+   margin-bottom: var(--space-9);
 }
 </style>

--- a/components/TagPage.vue
+++ b/components/TagPage.vue
@@ -15,7 +15,14 @@
       >
       <v-spacer size="triple" />
     </div>
+
     <!-- header & top page zone -->
+
+    <div class="gothamist-banners l-container l-container--xl l-wrap">
+      <gothamist-breaking-news class="l-container l-container--16col" />
+      <gothamist-marketing-banners class="l-container l-container--16col" />
+    </div>
+
     <div class="l-container l-container--14col l-wrap">
       <header v-if="title">
         <h1 class="tags-page-header">
@@ -195,6 +202,8 @@ export default {
   name: 'Section',
   components: {
     ArticleMetadata: () => import('nypr-design-system-vue/src/components/ArticleMetadata'),
+    GothamistMarketingBanners: () => import('../components/GothamistMarketingBanners'),
+    GothamistBreakingNews: () => import('../components/GothamistBreakingNews'),
     LoadingIcon: () => import('nypr-design-system-vue/src/components/animations/LoadingIcon'),
     VButton: () => import('nypr-design-system-vue/src/components/VButton'),
     VCard: () => import('nypr-design-system-vue/src/components/VCard'),

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -26,7 +26,7 @@
     </div>
     <gothamist-header />
     <main :class="$route.name">
-      <div class="gothamist-banners l-container l-container--xl l-wrap">
+      <div v-if="this.$route.name !== 'tags-slug'" class="gothamist-banners l-container l-container--xl l-wrap">
         <gothamist-breaking-news class="l-container l-container--16col" />
         <gothamist-marketing-banners class="l-container l-container--16col" />
       </div>
@@ -130,6 +130,10 @@ html {
 
 .home-page .gothamist-header {
   padding-bottom: 45px; //overhanging logo height
+}
+
+.home-page .gothamist-banners:first-child {
+  padding-top: var(--space-6);
 }
 
 .ad-wrapper-outer {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -129,11 +129,7 @@ html {
 }
 
 .home-page .gothamist-header {
-  padding-bottom: 45px; //overhanging logo height
-}
-
-.home-page .gothamist-banners:first-child {
-  padding-top: var(--space-6);
+  padding-bottom: calc(45px +  var(--space-6)); //45px = overhanging logo height
 }
 
 .ad-wrapper-outer {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -26,38 +26,24 @@
     </div>
     <gothamist-header />
     <main :class="$route.name">
-      <div>
-        <div
-          v-for="(banner, index) in breakingNewsBanner"
-          :key="index"
-          class="l-container l-container--xl l-wrap no-print"
-        >
-          <template v-if="banner.value">
-            <v-spacer size="double" />
-            <v-banner
-              tag="Breaking News"
-              :headline="banner.value.title"
-              :headline-link="banner.value.link"
-              :description="banner.value.description"
-            />
-          </template>
-        </div>
-      </div>
-      <div>
-        <div
-          v-for="(banner, index) in productMarketingBanner"
-          :key="index"
-          class="l-container l-container--xl l-wrap"
-        >
-          <template v-if="banner.value">
-            <v-spacer size="double" />
-            <product-marketing-banner
-              :title="banner.value.title"
-              :description="banner.value.description"
-              :cta="banner.value.buttonText"
-              :link="banner.value.buttonLink"
-            />
-          </template>
+      <div class="gothamist-banners l-container l-container--xl l-wrap">
+        <gothamist-breaking-news class="l-container l-container--16col" />
+        <div>
+          <div
+            v-for="(banner, index) in productMarketingBanner"
+            :key="index"
+            class="l-container l-container--xl l-wrap"
+          >
+            <template v-if="banner.value">
+              <v-spacer size="double" />
+              <product-marketing-banner
+                :title="banner.value.title"
+                :description="banner.value.description"
+                :cta="banner.value.buttonText"
+                :link="banner.value.buttonLink"
+              />
+            </template>
+          </div>
         </div>
       </div>
       <Nuxt />
@@ -72,15 +58,14 @@ import { mapState } from 'vuex'
 export default {
   name: 'Gothamist',
   components: {
-    VBanner: () => import('nypr-design-system-vue/src/components/VBanner'),
     GothamistFooter: () => import('../components/GothamistFooter'),
     GothamistHeader: () => import('../components/GothamistHeader'),
     ProductMarketingBanner: () => import('../components/ProductMarketingBanner'),
-    VSpacer: () => import('nypr-design-system-vue/src/components/VSpacer')
+    VSpacer: () => import('nypr-design-system-vue/src/components/VSpacer'),
+    GothamistBreakingNews: () => import('../components/GothamistBreakingNews')
   },
   data () {
     return {
-      breakingNewsBanner: null,
       productMarketingBanner: null
     }
   },
@@ -99,12 +84,6 @@ export default {
     this.setAdTargeting()
     // set the navigation
     await this.$store.dispatch('global/setNavigation')
-    // check for breaking news banner
-    await this.$axios
-      .get('/sitewide_components/1/')
-      .then(response => (
-        this.breakingNewsBanner = response.data.breakingNews
-      ))
     // check for product marketing banner
     await this.$axios
       .get('/system_messages/1/')

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -28,23 +28,7 @@
     <main :class="$route.name">
       <div class="gothamist-banners l-container l-container--xl l-wrap">
         <gothamist-breaking-news class="l-container l-container--16col" />
-        <div>
-          <div
-            v-for="(banner, index) in productMarketingBanner"
-            :key="index"
-            class="l-container l-container--xl l-wrap"
-          >
-            <template v-if="banner.value">
-              <v-spacer size="double" />
-              <product-marketing-banner
-                :title="banner.value.title"
-                :description="banner.value.description"
-                :cta="banner.value.buttonText"
-                :link="banner.value.buttonLink"
-              />
-            </template>
-          </div>
-        </div>
+        <gothamist-marketing-banners class="l-container l-container--16col" />
       </div>
       <Nuxt />
     </main>
@@ -60,14 +44,8 @@ export default {
   components: {
     GothamistFooter: () => import('../components/GothamistFooter'),
     GothamistHeader: () => import('../components/GothamistHeader'),
-    ProductMarketingBanner: () => import('../components/ProductMarketingBanner'),
-    VSpacer: () => import('nypr-design-system-vue/src/components/VSpacer'),
+    GothamistMarketingBanners: () => import('../components/GothamistMarketingBanners'),
     GothamistBreakingNews: () => import('../components/GothamistBreakingNews')
-  },
-  data () {
-    return {
-      productMarketingBanner: null
-    }
   },
   computed: {
     isHomepage () {
@@ -84,12 +62,6 @@ export default {
     this.setAdTargeting()
     // set the navigation
     await this.$store.dispatch('global/setNavigation')
-    // check for product marketing banner
-    await this.$axios
-      .get('/system_messages/1/')
-      .then(response => (
-        this.productMarketingBanner = response.data.productBanners
-      ))
   },
   methods: {
     setAdTargeting () {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -152,7 +152,8 @@ export default {
     axios: {
       baseURL: process.env.API
     },
-    environment: process.env.ENV && process.env.ENV.toLowerCase()
+    environment: process.env.ENV && process.env.ENV.toLowerCase(),
+    siteId: '1'
   },
 
   gtm: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <div class="l-container l-container--xl c-featured-blocks__wrapper">
-      <v-spacer size="triple" />
       <!-- featured area -->
       <loading-icon v-if="!featuredStoriesLoaded" />
       <section


### PR DESCRIPTION
- moved breaking news banners section into separate component
- moved product marketing banners section into separate component
- moved the "magic number" in the banner api calls to config, this "1" is actually the site id in the cms. I doubt we'll ever change it but hey it's one less value that's hardcoded into strings in the code
- relocated banners when on tag page so they appear below the curated header
- messed with margins and padding to get them to look good on each template both when there are banners and when there are no banners