### PR TITLE
Fix names for block quote, pull quote, and embeds

### DIFF
--- a/components/VStreamfield.vue
+++ b/components/VStreamfield.vue
@@ -2,10 +2,10 @@
   <div class="streamfield o-rte-text">
     <template v-for="block in streamfield">
       <!-- block-quote -->
-      <div v-if="block.type === 'block-quote'" :key="block.id" class="streamfield-block-quote">
+      <div v-if="block.type === 'block_quote'" :key="block.id" class="streamfield-block-quote">
         <blockquote>
           <p>
-            {{ block.value.block_quote }}
+            {{ block.value.blockQuote }}
           </p>
         </blockquote>
       </div>
@@ -51,7 +51,7 @@
         v-else-if="block.type === 'embed'"
         :key="block.id"
         class="streamfield-embed"
-        v-html="block.value.code"
+        v-html="block.value.embed"
       />
 
       <!-- heading -->
@@ -92,7 +92,7 @@
       <!-- pull-quote -->
       <div v-else-if="block.type === 'pull-quote'" :key="block.id" class="streamfield-pull-quote">
         <pull-quote
-          :quote="block.value.pull_quote"
+          :quote="block.value.pullQuote"
           :author="block.value.attribution"
         />
       </div>


### PR DESCRIPTION
- change attribute names to camelCase for embed, block quote and pull quote
- change block quote type value from `block-quote` to the correct `block_quote`