### PR TITLE
GOTH-175 Fix for list styles not showing as well as some issues with ad loading etc

### DIFF
--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -549,7 +549,9 @@ export default {
     },
     insertAd () {
       if (this.article && this.$refs['article-body'] && !this.article.sensitiveContent) {
-        insertAdDiv('insertedAd', this.$refs['article-body'].$el, { classNames: ['htlad-interior_midpage_1', 'ad-div', 'mod-break-margins', 'mod-ad-disclosure'], reset: true })
+        this.$nextTick(() => {
+          insertAdDiv('insertedAd', this.$refs['article-body'].$el, { classNames: ['htlad-interior_midpage_1', 'ad-div', 'mod-break-margins', 'mod-ad-disclosure'], reset: true })
+        })
       }
     }
   },

--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -175,7 +175,7 @@
 import gtm from '@/mixins/gtm'
 import disqus from '@/mixins/disqus'
 import { getImagePath } from '~/mixins/image'
-import { insertAdDiv, unwrapText } from '~/utils/insert-ad-div'
+import { insertAdDiv } from '~/utils/insert-ad-div'
 
 const {
   handleScroll
@@ -548,7 +548,6 @@ export default {
       document.querySelector('#comments')?.scrollIntoView()
     },
     insertAd () {
-      unwrapText(this.$refs['article-body'].$el)
       if (this.article && this.$refs['article-body'] && !this.article.sensitiveContent) {
         insertAdDiv('insertedAd', this.$refs['article-body'].$el, { classNames: ['htlad-interior_midpage_1', 'ad-div', 'mod-break-margins', 'mod-ad-disclosure'], reset: true })
       }

--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -105,6 +105,7 @@
         class="l-container l-container--10col article-body c-article__body"
         :streamfield="article.body"
         @hook:mounted="insertAd"
+        @hook:updated="insertAd"
       />
       <v-spacer size="quad" />
       <div
@@ -549,7 +550,7 @@ export default {
     },
     insertAd () {
       if (this.article && this.$refs['article-body'] && !this.article.sensitiveContent) {
-        this.$nextTick(() => {
+        this.$refs['article-body'].$nextTick(() => {
           insertAdDiv('insertedAd', this.$refs['article-body'].$el, { classNames: ['htlad-interior_midpage_1', 'ad-div', 'mod-break-margins', 'mod-ad-disclosure'], reset: true })
         })
       }

--- a/components/HtmlFragment.vue
+++ b/components/HtmlFragment.vue
@@ -1,0 +1,24 @@
+<template>
+  <div v-html="html" />
+</template>
+<script>
+export default {
+  props: {
+    html: { type: String, required: false, default: null }
+  },
+  mounted () {
+    const element = this.$el
+    const parent = element.parentNode
+
+    // Move all children node to the parent
+    while (element.firstChild) {
+      element.firstChild.classList?.add('streamfield-block')
+      parent.insertBefore(element.firstChild, element)
+    }
+
+    // `element` becomes an empty element
+    // Remove it from the parent
+    parent.removeChild(element)
+  }
+}
+</script>

--- a/components/VStreamfield.vue
+++ b/components/VStreamfield.vue
@@ -15,11 +15,11 @@
       </div>
 
       <!-- code -->
-      <div
+      <html-fragment
         v-else-if="block.type === 'code'"
         :key="block.id"
         class="streamfield-code u-spacing"
-        v-html="block.value.code"
+        :html="block.value.code"
       />
 
       <!-- content collection -->
@@ -86,11 +86,11 @@
       </div>
 
       <!-- paragraph -->
-      <div
+      <html-fragment
         v-else-if="block.type === 'paragraph'"
         :key="block.id"
         class="streamfield-paragraph u-spacing"
-        v-html="block.value"
+        :html="block.value"
       />
 
       <!-- pull-quote -->
@@ -119,6 +119,7 @@ const {
 export default {
   name: 'Streamfield',
   components: {
+    HtmlFragment: () => import('@/components/HtmlFragment'),
     ArticleMetadata: () => import('nypr-design-system-vue/src/components/ArticleMetadata'),
     ImageWithCaption: () => import('nypr-design-system-vue/src/components/ImageWithCaption'),
     PullQuote: () => import('nypr-design-system-vue/src/components/PullQuote'),

--- a/components/VStreamfield.vue
+++ b/components/VStreamfield.vue
@@ -131,7 +131,7 @@ export default {
       default: () => []
     }
   },
-  beforeMount () {
+  mounted () {
     // you can't have script tags in v-html
     // so we need to load the twitter embeds script manually
     if (window.twttr) {

--- a/components/VStreamfield.vue
+++ b/components/VStreamfield.vue
@@ -131,7 +131,7 @@ export default {
       default: () => []
     }
   },
-  mounted () {
+  beforeMount () {
     // you can't have script tags in v-html
     // so we need to load the twitter embeds script manually
     if (window.twttr) {

--- a/utils/insert-ad-div.js
+++ b/utils/insert-ad-div.js
@@ -48,31 +48,7 @@ function _insertAtLocation (element, container, insertLocation) {
   }
 }
 
-function _unwrapElement (element) {
-  const parent = element.parentNode
-
-  // Move all children node to the parent
-  while (element.firstChild) {
-    element.firstChild.classList?.add('streamfield-block')
-    parent.insertBefore(element.firstChild, element)
-  }
-
-  // `element` becomes an empty element
-  // Remove it from the parent
-  parent.removeChild(element)
-}
-
 let target
-
-// remove the wrapper elements so paragraphs are top level elements
-const unwrapText = function (container) {
-  container.childNodes.forEach((element) => {
-    if (element.classList?.contains('streamfield-paragraph') || // article text
-        element.classList?.contains('streamfield-code')) { // legacy articles are just html in code blocks
-      _unwrapElement(element)
-    }
-  })
-}
 
 /**
   Inserts a div into a story's DOM based on the following rules.
@@ -117,6 +93,7 @@ const insertAdDiv = function (divId, container, { wordsBeforeAd = 150, className
   })
   // Create the target div (or reuse it)
   if (reset) {
+    target?.parentNode.removeChild(target)
     target = document.createElement('div')
   } else {
     target = target || document.createElement('div')
@@ -131,6 +108,5 @@ const insertAdDiv = function (divId, container, { wordsBeforeAd = 150, className
 
 export default insertAdDiv
 export {
-  insertAdDiv,
-  unwrapText
+  insertAdDiv
 }


### PR DESCRIPTION
The timing of things here still feels a little weird, might just be the way things render on localhost. But i think things are a little more consistent now.

Still going with removing the div wrapper on streamfield rich text blocks for now instead of rewriting all the styles and ad insertion logic. (the reason list styles, for example, weren't showing up was because this failed sometimes, so they were in a wrapper div and the code expects them to be children on the article body)

I moved the code to make "wrapperless" html fragments into its own component that removes the wrapper div during `beforeMount`. It looks like there's a clever way suggested by one of the vue devs to do this directly in the components `render` method, https://jsfiddle.net/Linusborg/mfqjk5hm/ but I couldn't get that to play nice with Nuxt and this way is good enough.

Also played a little with the ad insertion code timing because it seems like that was running too early sometimes.