### PR TITLE
GOTH-184 Tag page loading

### DIFF
--- a/pages/tags/_slug.vue
+++ b/pages/tags/_slug.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="slug">
     <tag-page
-      v-if="page && dataLoaded"
+      v-if="page && !$fetchState.pending"
       :designed-header="page.designedHeader"
       :mid-page-zone="page.midpageZone"
       :slug="slug"
@@ -28,27 +28,26 @@ export default {
     TagPage: () => import('../../components/TagPage')
   },
   mixins: [gtm],
+  async fetch () {
+    await this.$axios
+      .get(`/pages/find/?html_path=tags/${this.slug}`)
+      .then((response) => {
+        this.page = response.data
+        this.title = this.page.title
+      })
+      .catch((e) => {
+        this.page = null
+        this.title = formatTitle(this.$route.params.slug)
+      })
+  },
   data () {
     return {
-      dataLoaded: false,
       page: null,
       slug: this.$route.params.slug,
       title: ''
     }
   },
-  async mounted () {
-    await this.$axios
-      .get(`/pages/find/?html_path=tags/${this.slug}`)
-      .then((response) => {
-        this.page = response.data
-        this.dataLoaded = true
-        this.title = this.page.title
-      })
-      .catch((e) => {
-        this.page = null
-        this.dataLoaded = true
-        this.title = formatTitle(this.$route.params.slug)
-      })
+  mounted () {
     setTargeting({ Template: 'Tag' })
   },
   beforeUnmount () {


### PR DESCRIPTION
Hopefully a fix for the intermittent tag page loading issue. Sometimes tag pages were failing to load any stories and showing a `TypeError: Cannot read property 'resolved' of undefined'` error in the console.  This was only happening intermittently so I can't say this fixes it for sure but i've made the following changes.

- refactor the `tags/_slug` page to load data in the Nuxt `fetch` hook instead of the `mounted` hook. A bonus advantage of this is we don't have to maintain our own loading state because we can use `$fetchState.pending`
- refactor the TagPage component to do the same. Using the fetch hook here also lets us reuse it in the moreResults call by calling fetch again with `this.$fetch`.

The issue is hard to reproduce and I can't be sure this fixes it but seems like a good step to take in any case. 