### PR TITLE
Change static deploy to skip generate and only deploy the static asset folder

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,6 @@ templates:
             env | sed -n "s/^${ENV}_//p" >> .env
             set -o allexport && source .env && set +o allexport
             npm install
-            npm run generate
             npm run deploy
 
   deploy_nuxt: &deploy_nuxt

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,8 +24,7 @@ const config = {
     /* 'Cache-Control': 'max-age=315360000, no-transform, public', */
   },
 
-  // Sensible Defaults - gitignore these Files and Dirs
-  distDir: 'dist',
+  distDir: 'static', // only deploy static asset folder
   indexRootPath: true,
   cacheFileName: '.awspublish',
   concurrentUploads: 10,


### PR DESCRIPTION
Change static deploy to skip `nuxt generate` and only deploy the `/static` asset folder.

By default nuxt generate does a lot of things and we don't any of them right now.