### PR TITLE
GOTH-175 Refactor logic for donate banner show/hiding into component

### DIFF
--- a/components/DismissibleArea.vue
+++ b/components/DismissibleArea.vue
@@ -1,0 +1,76 @@
+<template>
+  <div>
+    <slot v-if="shouldShow" :handleDismissed="handleDismissed" />
+  </div>
+</template>
+<script>
+/**
+   * Wrap an area to make it temporarily dismissible
+   *
+   * Usage Example:
+   * <dismissible-area prefix="Reminder1">
+   *    <template v-slot="dismissibleArea">
+   *      <div>
+   *        Reminder: Brush your teeth.
+   *        <button name="close" @click="dismissibleArea.handleDismissed">Close</button>
+   *      </div>
+   *    </template>
+   *  </dismissible-area>
+   */
+
+const oneMonth = 60 * 60 * 24 * 31
+export default {
+  props: {
+    /**
+     * A unique prefix used to name the cookies for this area.
+    */
+    prefix: {
+      type: String,
+      required: true
+    },
+    /**
+     * Delay actually showing this area until a certain number of pageviews.
+     * Resets when the banner is dismissed.
+     */
+    viewsBeforeShowable: {
+      type: Number,
+      default: 0
+    },
+    /**
+     * Number of seconds before showing the area again, once it's been dismissed.
+     */
+    dismissedTimeout: {
+      type: Number,
+      default: 60 * 60 * 24 // One day
+    }
+  },
+  data () {
+    return {
+      wasDismissed: false,
+      views: 0
+    }
+  },
+  computed: {
+    shouldShow () {
+      return !this.wasDismissed && (this.views >= this.viewsBeforeShowable)
+    }
+  },
+  beforeMount () {
+    this.wasDismissed = this.$cookies.get(`${this.prefix}Dismissed`)
+    if (!this.wasDismissed) {
+      const views = Number(this.$cookies.get(`${this.prefix}Views`)) || 0
+      this.views = views + 1
+      this.$cookies.set(`${this.prefix}Views`, this.views, { path: '/', maxAge: oneMonth })
+    }
+  },
+  methods: {
+    handleDismissed () {
+      this.wasDismissed = true
+      this.$cookies.set(`${this.prefix}Dismissed`, true, { path: '/', maxAge: this.dismissedTimeout })
+      this.$cookies.set(`${this.prefix}Views`, 0, { path: '/', maxAge: oneMonth })
+      this.showDonateBanner = false
+    }
+  }
+
+}
+</script>

--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -143,16 +143,19 @@
         <v-spacer size="quin" />
       </template>
 
-      <div
-        v-if="showDonateBanner"
-        v-observe-visibility="{callback: bannerVisibilityChanged, once: true}"
-      >
-        <donate-banner
-          :class="{'is-onscreen': bannerOnscreen}"
-          @close="bannerClosed"
-          @donate-click="bannerDonateClicked"
-        />
-      </div>
+      <dismissible-area prefix="donateBanner" :views-before-showable="3">
+        <template v-slot="dismissibleArea">
+          <div
+            v-observe-visibility="{callback: bannerVisibilityChanged, once: true}"
+          >
+            <donate-banner
+              :class="{'is-onscreen': bannerOnscreen}"
+              @close="dismissibleArea.handleDismissed"
+              @donate-click="bannerDonateClicked"
+            />
+          </div>
+        </template>
+      </dismissible-area>
     </div>
     <div
       v-else
@@ -199,6 +202,7 @@ export default {
     ReadMoreIn: () => import('./ReadMoreIn'),
     VTag: () => import('nypr-design-system-vue/src/components/VTag'),
     DoYouKnowTheScoop: () => import('./DoYouKnowTheScoop'),
+    DismissibleArea: () => import('./DismissibleArea'),
     DonateBanner: () => import('./DonateBanner'),
     ArticlePageNewsletter: () => import('./ArticlePageNewsletter'),
     RecirculationModule: () => import('./RecirculationModule')
@@ -213,12 +217,10 @@ export default {
   },
   data () {
     return {
-      bannerOnscreen: false,
       scrollPercent: 0,
       scrollPercent25Logged: false,
       scrollPercent50Logged: false,
       scrollPercent75Logged: false,
-      showDonateBanner: Number(this.$cookies.get('articleViews')) >= 3 && !this.$cookies.get('donateBannerDismissed'),
       path: 'https://gothamist.com' + this.$route.fullPath,
       ogImage: this.article.socialImage ??
         this.article.leadAsset[0]?.value.image ??
@@ -525,13 +527,6 @@ export default {
   methods: {
     articleGaEvent () {
       this.gaArticleEvent('NTG article milestone', this.gtmData.milestone + '%', this.gtmData.articleTitle, this.gtmData)
-    },
-    bannerClosed () {
-      // only show the banner once a day
-      const oneDay = 60 * 60 * 24
-      const oneMonth = 60 * 60 * 24 * 31
-      this.$cookies.set('donateBannerDismissed', true, { path: '/', maxAge: oneDay })
-      this.$cookies.set('articleViews', 0, { path: '/', maxAge: oneMonth })
     },
     bannerDonateClicked () {
       this.gaArticleEvent('Article Page', 'Donate Banner Clicked', this.gtmData.articleTitle, this.gtmData)

--- a/pages/_section/_article.vue
+++ b/pages/_section/_article.vue
@@ -2,7 +2,6 @@
   <div>
     <GothamistArticle
       :article="page"
-      :show-donate-banner="!cookies.donateBannerDismissed && cookies.articlesViewed >= 3"
     />
   </div>
 </template>
@@ -20,20 +19,9 @@ export default {
   mixins: [gtm],
   async asyncData ({
     $axios,
-    $cookies,
     params,
     error
   }) {
-    const donateBannerDismissed = $cookies.get('donateBannerDismissed') || false
-    const oneMonth = 60 * 60 * 24 * 31
-    let articleViews = Number($cookies.get('articleViews')) || 0
-    articleViews += 1
-    $cookies.set('articleViews', articleViews, { path: '/', maxAge: oneMonth })
-    const cookies = {
-      articleViews,
-      donateBannerDismissed
-    }
-
     const path = `${params.section}/${params.article}`
     const requestOptions = {
       transformResponse: $axios.defaults.transformResponse.concat(
@@ -68,8 +56,7 @@ export default {
     }
 
     return {
-      page: page?.data,
-      cookies
+      page: page?.data
     }
   },
   beforeMount () {


### PR DESCRIPTION
It looks like the issue in https://jira.wnyc.org/browse/GOTH-175 was caused by some weird timing with showing(?) or hiding(?) the article page donate banner based on the cookies... not sure exactly. But in any case there was some weird stuff going on there. 

The good news is for this type of component where it's halfway down the page and doesn't affect the layout, we don't even actually have a reason to handle it server side. So i've moved everything to client side cookie handling and furthermore moved all the cookie counting/expiring/reshowing/etc logic into a separate wrapper component that only handles that logic so i could learn how do that kind of thing in Vue.