### PR TITLE
GOTH-197 Fix for DOMException error when showing donate banner

### DIFF
--- a/components/DismissibleArea.vue
+++ b/components/DismissibleArea.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <slot v-if="shouldShow" :handleDismissed="handleDismissed" />
+    <slot v-show="shouldShow" :handleDismissed="handleDismissed" />
   </div>
 </template>
 <script>

--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -217,6 +217,7 @@ export default {
   },
   data () {
     return {
+      bannerOnscreen: false,
       scrollPercent: 0,
       scrollPercent25Logged: false,
       scrollPercent50Logged: false,


### PR DESCRIPTION
Looks like we were close, or in any case the last changes didn't make things worse. Tried this out on the demo tag and it looks good on demo.

- Using v-show instead of v-if to hide the banner.  Kind of a workaround more than a fix. It avoids runtime dom node manipulation all together (and thus DOM errors) by just using css to show hide instead of actually adding/removing the element. Only downside is the element always exists in the page, even when we don't want to show it, but in the big picture it's not a big deal.
- Adding back a missing property that got removed in the refactor that was causing things to not work even when the error didn't happen.