### PR TITLE
nc/GOTH-180

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -189,8 +189,10 @@ http {
         recursive_error_pages on;
         error_page 404 = @wagtail;
         location @wagtail {
-            # We need to append a trailing slash to the request so that Djando doesn't trigger a redirect loop
+            # We need to ensure there is a trailing slash to the request so that Djando doesn't trigger a redirect loop
+            rewrite ^/(.*)/$ /$1 permanent;
             proxy_pass $wagtail_origin$request_uri/;
+
             proxy_set_header Host $wagtail_host;
             proxy_set_header Origin $wagtail_origin;
             proxy_set_header X-Real-IP $remote_addr;
@@ -232,7 +234,7 @@ http {
 
    server {
         listen       80;
-        server_name  www.gothamist.com;
+        server_name  www.gothamist.com gothamist-vue.prod.nypr.digital;
         resolver     172.16.0.2 valid=60s;
 
         location / {


### PR DESCRIPTION
adding a rewrite to the @wagtail location block to ensure that there is exactly one trailing slash when proxying to aviary.

Take this example: there is a redirect in aviary for `/abc` -> `google.com`

The reason the redirects were failing before is that when gothamist.com/abc/ was hit the route being requested of aviary had 2 trailing slashes. Adding this rewrite ensures that when proxying back to wagtail, there will only ever be 1 trailing slash which is what wagtail wants.