### PR TITLE
GOTH-198 missing events

### DIFF
--- a/components/DisqusEmbed.vue
+++ b/components/DisqusEmbed.vue
@@ -78,6 +78,8 @@ export default {
     setBaseConfig (disqusConfig) {
       this.setPageConfig(disqusConfig)
       disqusConfig.language = 'en'
+      disqusConfig.callbacks.onReady = [() => { this.$emit('ready') }]
+      disqusConfig.callbacks.onNewComment = [(comment) => { this.$emit('new-comment', comment) }]
     },
     setPageConfig (disqusConfig) {
       const defaultConfig = {

--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -139,6 +139,7 @@
           v-if="article"
           :identifier="String(article.legacyId || article.uuid)"
           :url="article.url"
+          @new-comment="handleNewComment"
         />
         <v-spacer size="quin" />
       </template>
@@ -550,6 +551,9 @@ export default {
           insertAdDiv('insertedAd', this.$refs['article-body'].$el, { classNames: ['htlad-interior_midpage_1', 'ad-div', 'mod-break-margins', 'mod-ad-disclosure'], reset: true })
         })
       }
+    },
+    handleNewComment () {
+      this.gaEvent('NTG user', 'comment added', 'this.article?.title')
     }
   },
   head () {

--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -112,6 +112,11 @@
         class="l-container l-container--10col"
       >
         <article-page-newsletter
+          :key="article.uuid"
+          v-observe-visibility="{
+            callback: handleNewsletterImpression,
+            once: true,
+          }"
           title="NYC news never sleeps. Get the Gothamist Daily newsletter and don't miss a moment."
           class="article-newsletter"
           @newsletter-signup-success="handleNewsletterSignupSuccess"
@@ -555,6 +560,9 @@ export default {
     },
     handleNewComment () {
       this.gaEvent('NTG user', 'comment added', 'this.article?.title')
+    },
+    handleNewsletterImpression () {
+      this.gaEvent('NTG newsletter', 'newsletter modal impression 1', this.article.title)
     },
     handleNewsletterSignupSuccess () {
       this.gaEvent('NTG newsletter', 'newsletter signup', 'success')

--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -46,7 +46,7 @@
             service="facebook"
             :url="article.url"
             :utm-parameters="{medium: 'social', source: 'facebook', campaign: 'shared_facebook'}"
-            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','Social Share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -54,7 +54,7 @@
             :url="article.url"
             :share-parameters="{text: article.title, via: 'gothamist'}"
             :utm-parameters="{medium: 'social', source: 'twitter', campaign: 'shared_twitter'}"
-            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','Social Share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -62,7 +62,7 @@
             :url="article.url"
             :share-parameters="{title: article.title}"
             :utm-parameters="{medium: 'social', source: 'reddit', campaign: 'shared_reddit'}"
-            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','Social Share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -70,7 +70,7 @@
             :url="article.url"
             :share-parameters="{body: article.title + ' - %URL%'}"
             :utm-parameters="{medium: 'social', source: 'email', campaign: 'shared_email'}"
-            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','Social Share', ...arguments)"
           />
         </share-tools>
         <div

--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -563,7 +563,7 @@ export default {
       }
     },
     handleNewComment () {
-      this.gaEvent('NTG user', 'comment added', 'this.article?.title')
+      this.gaEvent('NTG user', 'comment added', this.article?.title)
     },
     handleNewsletterImpression () {
       this.gaEvent('NTG newsletter', 'newsletter modal impression 1', this.article.title)

--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -46,7 +46,7 @@
             service="facebook"
             :url="article.url"
             :utm-parameters="{medium: 'social', source: 'facebook', campaign: 'shared_facebook'}"
-            @share="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','social share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -54,7 +54,7 @@
             :url="article.url"
             :share-parameters="{text: article.title, via: 'gothamist'}"
             :utm-parameters="{medium: 'social', source: 'twitter', campaign: 'shared_twitter'}"
-            @share="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','social share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -62,7 +62,7 @@
             :url="article.url"
             :share-parameters="{title: article.title}"
             :utm-parameters="{medium: 'social', source: 'reddit', campaign: 'shared_reddit'}"
-            @share="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','social share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -70,7 +70,7 @@
             :url="article.url"
             :share-parameters="{body: article.title + ' - %URL%'}"
             :utm-parameters="{medium: 'social', source: 'email', campaign: 'shared_email'}"
-            @share="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','social share', ...arguments)"
           />
         </share-tools>
         <div

--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -114,6 +114,7 @@
         <article-page-newsletter
           title="NYC news never sleeps. Get the Gothamist Daily newsletter and don't miss a moment."
           class="article-newsletter"
+          @newsletter-signup-success="handleNewsletterSignupSuccess"
         />
         <div class="article-tag-list">
           <v-tag
@@ -554,6 +555,9 @@ export default {
     },
     handleNewComment () {
       this.gaEvent('NTG user', 'comment added', 'this.article?.title')
+    },
+    handleNewsletterSignupSuccess () {
+      this.gaEvent('NTG newsletter', 'newsletter signup', 'success')
     }
   },
   head () {

--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -571,7 +571,7 @@ export default {
       }
     },
     handleNewsletterSignupSuccess () {
-      this.gaEvent('NTG newsletter', 'newsletter signup', 'success')
+      this.gaEvent('NTG newsletter', 'newsletter signup 1', 'success')
     }
   },
   head () {

--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -565,8 +565,10 @@ export default {
     handleNewComment () {
       this.gaEvent('NTG user', 'comment added', this.article?.title)
     },
-    handleNewsletterImpression () {
-      this.gaEvent('NTG newsletter', 'newsletter modal impression 1', this.article.title)
+    handleNewsletterImpression (isVisible) {
+      if (isVisible) {
+        this.gaEvent('NTG newsletter', 'newsletter modal impression 1', this.article.title)
+      }
     },
     handleNewsletterSignupSuccess () {
       this.gaEvent('NTG newsletter', 'newsletter signup', 'success')

--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -46,6 +46,7 @@
             service="facebook"
             :url="article.url"
             :utm-parameters="{medium: 'social', source: 'facebook', campaign: 'shared_facebook'}"
+            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -53,6 +54,7 @@
             :url="article.url"
             :share-parameters="{text: article.title, via: 'gothamist'}"
             :utm-parameters="{medium: 'social', source: 'twitter', campaign: 'shared_twitter'}"
+            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -60,6 +62,7 @@
             :url="article.url"
             :share-parameters="{title: article.title}"
             :utm-parameters="{medium: 'social', source: 'reddit', campaign: 'shared_reddit'}"
+            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -67,6 +70,7 @@
             :url="article.url"
             :share-parameters="{body: article.title + ' - %URL%'}"
             :utm-parameters="{medium: 'social', source: 'email', campaign: 'shared_email'}"
+            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
           />
         </share-tools>
         <div

--- a/components/GothamistFooter.vue
+++ b/components/GothamistFooter.vue
@@ -21,22 +21,22 @@
             <share-tools-item
               service="facebook"
               username="gothamist"
-              @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+              @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
             />
             <share-tools-item
               service="twitter"
               username="gothamist"
-              @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+              @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
             />
             <share-tools-item
               service="instagram"
               username="gothamist"
-              @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+              @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
             />
             <share-tools-item
               service="youtube"
               username="UCY_2VeS5Q9_sMZRhtvF0c5Q"
-              @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+              @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
             />
           </share-tools>
         </div>

--- a/components/GothamistFooter.vue
+++ b/components/GothamistFooter.vue
@@ -21,22 +21,22 @@
             <share-tools-item
               service="facebook"
               username="gothamist"
-              @follow="gaEvent('NTG social','Social Follow', ...arguments)"
+              @follow="gaEvent('NTG social','social follow', ...arguments)"
             />
             <share-tools-item
               service="twitter"
               username="gothamist"
-              @follow="gaEvent('NTG social','Social Follow', ...arguments)"
+              @follow="gaEvent('NTG social','social follow', ...arguments)"
             />
             <share-tools-item
               service="instagram"
               username="gothamist"
-              @follow="gaEvent('NTG social','Social Follow', ...arguments)"
+              @follow="gaEvent('NTG social','social follow', ...arguments)"
             />
             <share-tools-item
               service="youtube"
               username="UCY_2VeS5Q9_sMZRhtvF0c5Q"
-              @follow="gaEvent('NTG social','Social Follow', ...arguments)"
+              @follow="gaEvent('NTG social','social follow', ...arguments)"
             />
           </share-tools>
         </div>

--- a/components/GothamistFooter.vue
+++ b/components/GothamistFooter.vue
@@ -44,10 +44,8 @@
       <template v-slot:rightComponent>
         <div>
           <gothamist-footer-newsletter
-            :key="$route.path"
             v-observe-visibility="{
               callback: handleNewsletterImpression,
-              once: true,
             }"
             @newsletter-signup-success="handleNewsletterSignupSuccess"
           />
@@ -73,6 +71,11 @@ export default {
     BackToTop: () => import('../components/BackToTop')
   },
   mixins: [gtm],
+  data () {
+    return {
+      newsLetterImpressionTracked: false
+    }
+  },
   computed: {
     ...mapState('global', {
       footerNav: state => state.footerNav,
@@ -80,9 +83,17 @@ export default {
       legalNav: state => state.legalNav
     })
   },
+  watch: {
+    '$route.path' () {
+      this.newsLetterImpressionTracked = false
+    }
+  },
   methods: {
-    handleNewsletterImpression () {
-      this.gaEvent('NTG newsletter', 'newsletter modal impression 2', 'footer')
+    handleNewsletterImpression (isVisible) {
+      if (isVisible) {
+        this.gaEvent('NTG newsletter', 'newsletter modal impression 2', 'footer')
+        this.newsLetterImpressionTracked = true
+      }
     },
     handleNewsletterSignupSuccess () {
       this.gaEvent('NTG newsletter', 'newsletter signup', 'success')

--- a/components/GothamistFooter.vue
+++ b/components/GothamistFooter.vue
@@ -96,7 +96,7 @@ export default {
       }
     },
     handleNewsletterSignupSuccess () {
-      this.gaEvent('NTG newsletter', 'newsletter signup', 'success')
+      this.gaEvent('NTG newsletter', 'newsletter signup 2', 'success')
     }
   }
 }

--- a/components/GothamistFooter.vue
+++ b/components/GothamistFooter.vue
@@ -73,7 +73,7 @@ export default {
   mixins: [gtm],
   data () {
     return {
-      newsLetterImpressionTracked: false
+      newsletterImpressionWasTracked: false
     }
   },
   computed: {
@@ -85,14 +85,14 @@ export default {
   },
   watch: {
     '$route.path' () {
-      this.newsLetterImpressionTracked = false
+      this.newsletterImpressionWasTracked = false
     }
   },
   methods: {
     handleNewsletterImpression (isVisible) {
-      if (isVisible) {
+      if (isVisible && !this.newsletterImpressionWasTracked) {
         this.gaEvent('NTG newsletter', 'newsletter modal impression 2', 'footer')
-        this.newsLetterImpressionTracked = true
+        this.newsletterImpressionWasTracked = true
       }
     },
     handleNewsletterSignupSuccess () {

--- a/components/GothamistFooter.vue
+++ b/components/GothamistFooter.vue
@@ -49,7 +49,7 @@
               callback: handleNewsletterImpression,
               once: true,
             }"
-            @newletter-signup-success="handleNewsletterSignupSuccess"
+            @newsletter-signup-success="handleNewsletterSignupSuccess"
           />
         </div>
       </template>

--- a/components/GothamistFooter.vue
+++ b/components/GothamistFooter.vue
@@ -44,6 +44,11 @@
       <template v-slot:rightComponent>
         <div>
           <gothamist-footer-newsletter
+            :key="$route.path"
+            v-observe-visibility="{
+              callback: handleNewsletterImpression,
+              once: true,
+            }"
             @newletter-signup-success="handleNewsletterSignupSuccess"
           />
         </div>
@@ -76,6 +81,9 @@ export default {
     })
   },
   methods: {
+    handleNewsletterImpression () {
+      this.gaEvent('NTG newsletter', 'newsletter modal impression 2', 'footer')
+    },
     handleNewsletterSignupSuccess () {
       this.gaEvent('NTG newsletter', 'newsletter signup', 'success')
     }

--- a/components/GothamistFooter.vue
+++ b/components/GothamistFooter.vue
@@ -21,22 +21,22 @@
             <share-tools-item
               service="facebook"
               username="gothamist"
-              @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
+              @follow="gaEvent('NTG social','Social Follow', ...arguments)"
             />
             <share-tools-item
               service="twitter"
               username="gothamist"
-              @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
+              @follow="gaEvent('NTG social','Social Follow', ...arguments)"
             />
             <share-tools-item
               service="instagram"
               username="gothamist"
-              @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
+              @follow="gaEvent('NTG social','Social Follow', ...arguments)"
             />
             <share-tools-item
               service="youtube"
               username="UCY_2VeS5Q9_sMZRhtvF0c5Q"
-              @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
+              @follow="gaEvent('NTG social','Social Follow', ...arguments)"
             />
           </share-tools>
         </div>

--- a/components/GothamistFooter.vue
+++ b/components/GothamistFooter.vue
@@ -43,7 +43,9 @@
       </template>
       <template v-slot:rightComponent>
         <div>
-          <gothamist-footer-newsletter />
+          <gothamist-footer-newsletter
+            @newletter-signup-success="handleNewsletterSignupSuccess"
+          />
         </div>
       </template>
     </the-footer>
@@ -72,6 +74,11 @@ export default {
       footerSlogan: state => state.footerSlogan,
       legalNav: state => state.legalNav
     })
+  },
+  methods: {
+    handleNewsletterSignupSuccess () {
+      this.gaEvent('NTG newsletter', 'newsletter signup', 'success')
+    }
   }
 }
 </script>

--- a/components/GothamistHeader.vue
+++ b/components/GothamistHeader.vue
@@ -63,22 +63,22 @@
                 <share-tools-item
                   service="facebook"
                   username="gothamist"
-                  @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
+                  @follow="gaEvent('NTG social','Social Follow', ...arguments)"
                 />
                 <share-tools-item
                   service="twitter"
                   username="gothamist"
-                  @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
+                  @follow="gaEvent('NTG social','Social Follow', ...arguments)"
                 />
                 <share-tools-item
                   service="instagram"
                   username="gothamist"
-                  @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
+                  @follow="gaEvent('NTG social','Social Follow', ...arguments)"
                 />
                 <share-tools-item
                   service="youtube"
                   username="UCY_2VeS5Q9_sMZRhtvF0c5Q"
-                  @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
+                  @follow="gaEvent('NTG social','Social Follow', ...arguments)"
                 />
               </share-tools>
             </div>
@@ -135,7 +135,7 @@
             service="facebook"
             :url="url + '&utm_medium=social&utm_source=facebook&utm_campaign=shared_facebook'"
             :utm-parameters="{medium: 'social', source: 'facebook', campaign: 'shared_facebook'}"
-            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','Social Share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -143,7 +143,7 @@
             :url="url + '&utm_medium=social&utm_source=twitter&utm_campaign=shared_twitter'"
             :share-parameters="{text: title, via: 'gothamist'}"
             :utm-parameters="{medium: 'social', source: 'twitter', campaign: 'shared_twitter'}"
-            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','Social Share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -151,7 +151,7 @@
             :url="url + '&utm_medium=social&utm_source=reddit&utm_campaign=shared_reddit'"
             :share-parameters="{title: title}"
             :utm-parameters="{medium: 'social', source: 'reddit', campaign: 'shared_reddit'}"
-            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','Social Share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -159,7 +159,7 @@
             :url="url"
             :share-parameters="{body: title + ' - %URL%'}"
             :utm-parameters="{medium: 'social', source: 'email', campaign: 'shared_email'}"
-            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','Social Share', ...arguments)"
           />
         </share-tools>
       </template>

--- a/components/GothamistHeader.vue
+++ b/components/GothamistHeader.vue
@@ -63,22 +63,22 @@
                 <share-tools-item
                   service="facebook"
                   username="gothamist"
-                  @follow="gaEvent('NTG social','Social Follow', ...arguments)"
+                  @follow="gaEvent('NTG social','social follow', ...arguments)"
                 />
                 <share-tools-item
                   service="twitter"
                   username="gothamist"
-                  @follow="gaEvent('NTG social','Social Follow', ...arguments)"
+                  @follow="gaEvent('NTG social','social follow', ...arguments)"
                 />
                 <share-tools-item
                   service="instagram"
                   username="gothamist"
-                  @follow="gaEvent('NTG social','Social Follow', ...arguments)"
+                  @follow="gaEvent('NTG social','social follow', ...arguments)"
                 />
                 <share-tools-item
                   service="youtube"
                   username="UCY_2VeS5Q9_sMZRhtvF0c5Q"
-                  @follow="gaEvent('NTG social','Social Follow', ...arguments)"
+                  @follow="gaEvent('NTG social','social follow', ...arguments)"
                 />
               </share-tools>
             </div>
@@ -135,7 +135,7 @@
             service="facebook"
             :url="url + '&utm_medium=social&utm_source=facebook&utm_campaign=shared_facebook'"
             :utm-parameters="{medium: 'social', source: 'facebook', campaign: 'shared_facebook'}"
-            @share="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','social', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -143,7 +143,7 @@
             :url="url + '&utm_medium=social&utm_source=twitter&utm_campaign=shared_twitter'"
             :share-parameters="{text: title, via: 'gothamist'}"
             :utm-parameters="{medium: 'social', source: 'twitter', campaign: 'shared_twitter'}"
-            @share="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','social', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -151,7 +151,7 @@
             :url="url + '&utm_medium=social&utm_source=reddit&utm_campaign=shared_reddit'"
             :share-parameters="{title: title}"
             :utm-parameters="{medium: 'social', source: 'reddit', campaign: 'shared_reddit'}"
-            @share="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','social', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -159,7 +159,7 @@
             :url="url"
             :share-parameters="{body: title + ' - %URL%'}"
             :utm-parameters="{medium: 'social', source: 'email', campaign: 'shared_email'}"
-            @share="gaEvent('NTG social','Social Share', ...arguments)"
+            @share="gaEvent('NTG social','social', ...arguments)"
           />
         </share-tools>
       </template>

--- a/components/GothamistHeader.vue
+++ b/components/GothamistHeader.vue
@@ -63,22 +63,22 @@
                 <share-tools-item
                   service="facebook"
                   username="gothamist"
-                  @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+                  @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
                 />
                 <share-tools-item
                   service="twitter"
                   username="gothamist"
-                  @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+                  @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
                 />
                 <share-tools-item
                   service="instagram"
                   username="gothamist"
-                  @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+                  @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
                 />
                 <share-tools-item
                   service="youtube"
                   username="UCY_2VeS5Q9_sMZRhtvF0c5Q"
-                  @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
+                  @componentEvent="gaEvent('NTG social','Social Follow', ...arguments)"
                 />
               </share-tools>
             </div>

--- a/components/GothamistHeader.vue
+++ b/components/GothamistHeader.vue
@@ -135,7 +135,7 @@
             service="facebook"
             :url="url + '&utm_medium=social&utm_source=facebook&utm_campaign=shared_facebook'"
             :utm-parameters="{medium: 'social', source: 'facebook', campaign: 'shared_facebook'}"
-            @share="gaEvent('NTG social','social', ...arguments)"
+            @share="gaEvent('NTG social','social share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -143,7 +143,7 @@
             :url="url + '&utm_medium=social&utm_source=twitter&utm_campaign=shared_twitter'"
             :share-parameters="{text: title, via: 'gothamist'}"
             :utm-parameters="{medium: 'social', source: 'twitter', campaign: 'shared_twitter'}"
-            @share="gaEvent('NTG social','social', ...arguments)"
+            @share="gaEvent('NTG social','social share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -151,7 +151,7 @@
             :url="url + '&utm_medium=social&utm_source=reddit&utm_campaign=shared_reddit'"
             :share-parameters="{title: title}"
             :utm-parameters="{medium: 'social', source: 'reddit', campaign: 'shared_reddit'}"
-            @share="gaEvent('NTG social','social', ...arguments)"
+            @share="gaEvent('NTG social','social share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -159,7 +159,7 @@
             :url="url"
             :share-parameters="{body: title + ' - %URL%'}"
             :utm-parameters="{medium: 'social', source: 'email', campaign: 'shared_email'}"
-            @share="gaEvent('NTG social','social', ...arguments)"
+            @share="gaEvent('NTG social','social share', ...arguments)"
           />
         </share-tools>
       </template>

--- a/components/GothamistHeader.vue
+++ b/components/GothamistHeader.vue
@@ -134,18 +134,24 @@
             action="share"
             service="facebook"
             :url="url + '&utm_medium=social&utm_source=facebook&utm_campaign=shared_facebook'"
+            :utm-parameters="{medium: 'social', source: 'facebook', campaign: 'shared_facebook'}"
+            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
           />
           <share-tools-item
             action="share"
             service="twitter"
             :url="url + '&utm_medium=social&utm_source=twitter&utm_campaign=shared_twitter'"
             :share-parameters="{text: title, via: 'gothamist'}"
+            :utm-parameters="{medium: 'social', source: 'twitter', campaign: 'shared_twitter'}"
+            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
           />
           <share-tools-item
             action="share"
             service="reddit"
             :url="url + '&utm_medium=social&utm_source=reddit&utm_campaign=shared_reddit'"
             :share-parameters="{title: title}"
+            :utm-parameters="{medium: 'social', source: 'reddit', campaign: 'shared_reddit'}"
+            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
           />
           <share-tools-item
             action="share"
@@ -153,6 +159,7 @@
             :url="url"
             :share-parameters="{body: title + ' - %URL%'}"
             :utm-parameters="{medium: 'social', source: 'email', campaign: 'shared_email'}"
+            @componentEvent="gaEvent('NTG social','Social Share', ...arguments)"
           />
         </share-tools>
       </template>

--- a/mixins/newsletter.js
+++ b/mixins/newsletter.js
@@ -38,13 +38,13 @@ export default {
         )
         .then(() => {
           this.status = 'success'
+          this.$emit('newsletter-signup-success')
           // gaEvent (gaCategory, gaAction, gaLabel, custom) {
-          this.gaEvent('NTG Newsletter', 'newsletter modal impression 2', location, 'success')
         })
         .catch(() => {
           this.status = 'error'
           this.submitted = false
-          this.gaEvent('NTG Newsletter', 'newsletter modal impression 2', location, 'error')
+          this.$emit('newsletter-signup-error')
         })
     }
   }

--- a/mixins/newsletter.js
+++ b/mixins/newsletter.js
@@ -39,7 +39,6 @@ export default {
         .then(() => {
           this.status = 'success'
           this.$emit('newsletter-signup-success')
-          // gaEvent (gaCategory, gaAction, gaLabel, custom) {
         })
         .catch(() => {
           this.status = 'error'

--- a/package-lock.json
+++ b/package-lock.json
@@ -12983,8 +12983,8 @@
       "dev": true
     },
     "nypr-design-system-vue": {
-      "version": "github:nypublicradio/nypr-design-system-vue#90a600ff442e7a56ffe44a9e19fcb1ccbd5c4959",
-      "from": "github:nypublicradio/nypr-design-system-vue#90a600ff442e7a56ffe44a9e19fcb1ccbd5c4959",
+      "version": "github:nypublicradio/nypr-design-system-vue#6f0bc1f3d9f9a17f656ff29655629ae32cbcde5a",
+      "from": "github:nypublicradio/nypr-design-system-vue#6f0bc1f3d9f9a17f656ff29655629ae32cbcde5a",
       "dev": true,
       "requires": {
         "@jest/globals": "^26.6.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jest": "^26.6.3",
     "jest-axe": "^5.0.1",
     "node-sass": "^4.14.1",
-    "nypr-design-system-vue": "github:nypublicradio/nypr-design-system-vue#90a600ff442e7a56ffe44a9e19fcb1ccbd5c4959",
+    "nypr-design-system-vue": "github:nypublicradio/nypr-design-system-vue#6f0bc1f3d9f9a17f656ff29655629ae32cbcde5a",
     "sass-loader": "^10.1.1",
     "vue-jest": "^3.0.4",
     "vue-lottie": "^0.2.1",

--- a/pages/newsletter.vue
+++ b/pages/newsletter.vue
@@ -72,7 +72,7 @@ export default {
   },
   methods: {
     handleNewsletterSignupSuccess () {
-      this.gaEvent('NTG newsletter', 'newsletter signup', 'success')
+      this.gaEvent('NTG newsletter', 'newsletter signup 3', 'success')
     }
   },
   head () {

--- a/pages/newsletter.vue
+++ b/pages/newsletter.vue
@@ -35,7 +35,9 @@
                   data-action="newsletter modal impression 3"
                   data-label="Newsletter Signup Page"
                 >
-                  <article-page-newsletter />
+                  <article-page-newsletter
+                    @newsletter-signup-success="handleNewsletterSignupSuccess"
+                  />
                 </div>
               </div>
             </div>
@@ -65,6 +67,11 @@ export default {
     VSpacer: () => import('nypr-design-system-vue/src/components/VSpacer')
   },
   mixins: [gtm],
+  methods: {
+    handleNewsletterSignupSuccess () {
+      this.gaEvent('NTG newsletter', 'newsletter signup', 'success')
+    }
+  },
   head () {
     return {
       title: 'Newsletter - Gothamist',

--- a/pages/newsletter.vue
+++ b/pages/newsletter.vue
@@ -67,6 +67,9 @@ export default {
     VSpacer: () => import('nypr-design-system-vue/src/components/VSpacer')
   },
   mixins: [gtm],
+  mounted () {
+    this.gaEvent('NTG newsletter', 'newsletter modal impression 3', 'Newsletter Signup Page')
+  },
   methods: {
     handleNewsletterSignupSuccess () {
       this.gaEvent('NTG newsletter', 'newsletter signup', 'success')


### PR DESCRIPTION
https://jira.wnyc.org/browse/GOTH-198

- [x] Depends on some small changes in the design system https://github.com/nypublicradio/nypr-design-system-vue/pull/194

Adds/ cleans up tracking for the following events
- 'NTG newsletter', 'newsletter modal impression [number]', title
- 'NTG newsletter', 'newsletter signup'
- 'NTG social', 'social share', service name
- 'NTG social', 'social follow', service name (we made this one up, not part of the News Tagging Guide)
- 'NTG user', 'comment added'

This affects events on: 
- Newsletter forms in footer, article page, /newsletter page
- Share buttons in header, next to article lead asset
- Follow buttons in footer, side menu
- Disqus comment embed

BONUS: adds utm parameters to the share buttons in the header


