### PR TITLE
GOTH-201 - Add canonical url link to head data

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -108,6 +108,11 @@ export default {
           rel: 'stylesheet',
           type: 'text/css',
           href: 'https://htlbid.com/v3/gothamistv2.com/htlbid.css'
+        },
+        {
+          hid: 'canonical_url',
+          href: 'https://gothamist.com' + this.$route.path,
+          rel: 'canonical'
         }
       ],
       script: [

--- a/pages/_section/_article.vue
+++ b/pages/_section/_article.vue
@@ -78,6 +78,17 @@ export default {
   beforeDestroy () {
     clearTargeting(['Template', 'tags', 'racy', 'Sponsor', 'Category'])
     this.$store.commit('global/setSensitiveContent', false)
+  },
+  head () {
+    return {
+      link: [
+        {
+          hid: 'canonical_url',
+          href: this.page?.canonicalUrl || 'https://gothamist.com' + this.$route.path,
+          rel: 'canonical'
+        }
+      ]
+    }
   }
 }
 </script>


### PR DESCRIPTION
- When an article has a canonical url override set in the CMS (on the promote tab), use that.
- For articles without overrides and all other page types, use `https://gothamist.com` and the path
- This technically isn't set on the error pages because they use a different layout template but i think we want that