### PR TITLE
Lazy load disqus embed

### DIFF
--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -141,9 +141,12 @@
 
       <div v-if="!article.sensitiveContent" class="htlad-interior_midpage_2 ad-div mod-break-margins mod-ad-disclosure no-print" />
 
-      <div id="comments" />
+      <div
+        id="comments"
+        v-observe-visibility="{callback: loadComments, intersection: { rootMargin: '300px 0px 0px 0px', threshold: 0.01 } }"
+      />
       <template
-        v-if="!article.disableComments"
+        v-if="!article.disableComments && showComments"
       >
         <disqus-embed
           v-if="article"
@@ -254,7 +257,8 @@ export default {
           name: 'twitter:site',
           content: '@gothamist'
         }
-      ]
+      ],
+      showComments: false
     }
   },
   computed: {
@@ -569,6 +573,12 @@ export default {
     },
     handleNewsletterSignupSuccess () {
       this.gaEvent('NTG newsletter', 'newsletter signup 1', 'success')
+    },
+    loadComments (isVisible) {
+      if (isVisible) {
+        this.showComments = true
+        console.log('load comments')
+      }
     }
   },
   head () {


### PR DESCRIPTION
- The disqus-embed component already handles loading of the disqus embed script so all we have to do here is defer loading of the component, which can be accomplished with a straightforward `v-if` directive.
- We use `v-observe-visibility` to check when the user has scrolled the comments into view. the following parameters extend an imaginary margin upwards from the observed element so we can be nice and actually start loading the comments 300px before the element appears.
`intersection: { rootMargin: '300px 0px 0px 0px', threshold: 0.01 } `