### PR TITLE
Lazily hydrate the article streamfield

### DIFF
--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -99,14 +99,16 @@
         </div>
       </div>
       <v-spacer size="double" />
-      <v-streamfield
-        :key="article.uuid"
-        ref="article-body"
-        class="l-container l-container--10col article-body c-article__body"
-        :streamfield="article.body"
-        @hook:mounted="insertAd"
-        @hook:updated="insertAd"
-      />
+      <LazyHydrate when-visible>
+        <v-streamfield
+          :key="article.uuid"
+          ref="article-body"
+          class="l-container l-container--10col article-body c-article__body"
+          :streamfield="article.body"
+          @hook:mounted="insertAd"
+          @hook:updated="insertAd"
+        />
+      </LazyHydrate>
       <v-spacer size="quad" />
       <div
         class="l-container l-container--10col"
@@ -178,6 +180,7 @@
 <script>
 import gtm from '@/mixins/gtm'
 import disqus from '@/mixins/disqus'
+import LazyHydrate from 'vue-lazy-hydration'
 import { getImagePath } from '~/mixins/image'
 import { insertAdDiv } from '~/utils/insert-ad-div'
 
@@ -188,6 +191,7 @@ const {
 export default {
   name: 'GothamistArticle',
   components: {
+    LazyHydrate,
     VStreamfield: () => import('./VStreamfield'),
     Breadcrumbs: () => import('./Breadcrumbs'),
     DisqusEmbed: () => import('./DisqusEmbed'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -18169,6 +18169,11 @@
         }
       }
     },
+    "vue-lazy-hydration": {
+      "version": "2.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/vue-lazy-hydration/-/vue-lazy-hydration-2.0.0-beta.4.tgz",
+      "integrity": "sha512-bhr7AxzrSEPed4cOawIeCxJmR8pglberR78x1zs0886xR+47/EXE9s0Ezss90CPINo8ApzUfA/r+SbNffn+t9w=="
+    },
     "vue-loader": {
       "version": "15.9.7",
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.9.7.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "humps": "^2.0.1",
     "nuxt": "^2.15.4",
     "package.json": "^2.0.1",
+    "vue-lazy-hydration": "^2.0.0-beta.4",
     "vue-mq": "^1.0.1",
     "vue-observe-visibility": "^1.0.0"
   },


### PR DESCRIPTION
This improves time to interactive during the first page load. 
Side effect: the first article inline ad isn't loaded until the article is scrolled into view.