### PR TITLE
Update nginx rules for news sitemap url

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -158,7 +158,7 @@ http {
         error_page   500 502 503 504  /50x.html;
 
         # site map
-        location ~ "^/sitemap(-\d{4})?\.xml$" {
+        location ~ "^/sitemap(-\w+)?\.xml$" {
             proxy_buffering off;
             proxy_pass $wagtail_origin;
             proxy_set_header Host $wagtail_host;


### PR DESCRIPTION
news sitemap is at `/sitemap-news.xml` just making the rule for the year based sections a little broader to allow any alphanumeric section name instead of only a 4 digit year