### PR TITLE
Deploy demo robots.txt when `ENV` is `demo`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,11 +19,13 @@ const config = {
   // Optional
   deleteOldVersions: false, // NOT FOR PRODUCTION
   distribution: process.env.AWS_CLOUDFRONT, // CloudFront distribution ID
+  env: process.env.ENV,
   region: process.env.AWS_DEFAULT_REGION,
   headers: {
     /* 'Cache-Control': 'max-age=315360000, no-transform, public', */
   },
 
+  demoAssetsDir: 'static-demo',
   distDir: 'static', // only deploy static asset folder
   indexRootPath: true,
   cacheFileName: '.awspublish',
@@ -35,8 +37,12 @@ gulp.task('deploy', function () {
   // create a new publisher using S3 options
   // http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property
   const publisher = awspublish.create(config)
-
-  let g = gulp.src('./' + config.distDir + '/**')
+  let g
+  if (config.env === 'demo') {
+    g = gulp.src(['./' + config.distDir + '/**', './' + config.demoAssetsDir + '/**'])
+  } else {
+    g = gulp.src('./' + config.distDir + '/**')
+  }
   // publisher will add Content-Length, Content-Type and headers specified above
   // If not specified it will set x-amz-acl to public-read by default
   g = g.pipe(

--- a/static-demo/robots.txt
+++ b/static-demo/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
When the `ENV` env var is set to `demo`, we include a demo assets folder. Since this folder is second in the array, it's processed second, so files with the same name will override existing files in the default folder.
This is a little bit inelegant in that it will publish the file at `assets/robots.txt` to S3 and then immediately update/replace it with `assets-static/robots.txt`, but it works and I think we're unlikely to use this pattern for larger files where this might matter more.

<details>
<summary>
Example of the deploy step in action on demo. Notice the second robots.txt update.
</summary>

```
[17:13:00] Using gulpfile ~/project/gulpfile.js
[17:13:00] Starting 'deploy'...
Configured with CloudFront distribution
[17:13:00] [skip]   README.md
[17:13:00] [skip]   ads.txt
[17:13:00] [skip]   favicon.ico
[17:13:00] [skip]   newsletter-icon.svg
[17:13:00] [skip]   maintenance.html
[17:13:00] [skip]   images/home_og_1200x650.png
[17:13:00] [skip]   images/logo.png
[17:13:00] [skip]   images/404.jpg
[17:13:00] [skip]   images/news-tile.png
[17:13:00] [skip]   static-images/404.jpg
[17:13:00] [skip]   static-images/logo.png
```
```
[17:13:00] [update] robots.txt
```
```
[17:13:00] [skip]   images/wtc.png
[17:13:00] [skip]   static-images/home_og_1200x650.png
[17:13:00] [skip]   images/staff/ben-yakas.jpg
[17:13:00] [skip]   static-images/news-tile.png
[17:13:00] [skip]   images/staff/elizabeth-kim.jpg
[17:13:00] [skip]   static-images/wtc.png
[17:13:00] [skip]   images/staff/christopher-robbins.jpg
[17:13:00] [skip]   images/staff/jake-offenhartz.jpg
[17:13:00] [skip]   images/staff/jen-carlson.jpg
[17:13:00] [skip]   images/staff/jake-dobkin.jpg
[17:13:00] [skip]   images/staff/jen-chung.jpg
[17:13:00] [skip]   images/staff/mei-lee.jpg
[17:13:00] [skip]   images/staff/tom-stern.jpg
[17:13:00] [skip]   static-images/staff/ben-yakas.jpg
[17:13:00] [skip]   static-images/staff/christopher-robbins.jpg
[17:13:00] [skip]   images/staff/paula-mejia.jpg
[17:13:00] [skip]   images/staff/john-del-signore.jpg
[17:13:01] [skip]   static-images/staff/elizabeth-kim.jpg
[17:13:01] [skip]   static-images/staff/jake-dobkin.jpg
[17:13:01] [skip]   static-images/staff/jen-carlson.jpg
[17:13:01] [skip]   static-images/staff/jen-chung.jpg
[17:13:01] [skip]   static-images/staff/john-del-signore.jpg
[17:13:01] [skip]   static-images/staff/paula-mejia.jpg
[17:13:01] [skip]   static-images/staff/tom-stern.jpg
[17:13:01] [skip]   images/defaults/arts/arts-sq.png
[17:13:01] [skip]   static-images/staff/jake-offenhartz.jpg
[17:13:01] [skip]   static-images/staff/mei-lee.jpg
[17:13:01] [skip]   images/defaults/arts/arts-sq@2x.png
[17:13:01] [skip]   images/defaults/arts/arts-tile.png
[17:13:01] [skip]   images/defaults/arts/arts-tile@2x.png
[17:13:01] [skip]   images/defaults/arts/arts-sq@3x.png
[17:13:01] [skip]   images/defaults/arts/arts-tile@3x.png
[17:13:01] [skip]   images/defaults/food/food-sq.png
[17:13:01] [skip]   images/defaults/food/food-sq@2x.png
[17:13:01] [skip]   images/defaults/food/food-sq@3x.png
[17:13:01] [skip]   images/defaults/food/food-tile.png
[17:13:01] [skip]   images/defaults/food/food-tile@2x.png
[17:13:01] [skip]   images/defaults/news/news-sq.png
[17:13:01] [skip]   images/defaults/news/news-sq@2x.png
[17:13:01] [skip]   images/defaults/news/news-sq@3x.png
[17:13:01] [skip]   images/defaults/food/food-tile@3x.png
[17:13:01] [skip]   images/defaults/news/news-tile.png
[17:13:01] [skip]   images/defaults/news/news-tile@2x.png
[17:13:01] [skip]   images/defaults/news/news-tile@3x.png
[17:13:01] [skip]   images/defaults/no-category/no-category-sq.png
[17:13:01] [skip]   images/defaults/no-category/no-category-sq@2x.png
[17:13:02] [skip]   images/defaults/no-category/no-category-sq@3x.png
[17:13:02] [skip]   images/defaults/no-category/no-category-tile.png
[17:13:02] [skip]   images/defaults/no-category/no-category-tile@3x.png
[17:13:02] [skip]   static-images/defaults/arts/arts-tile.png
[17:13:02] [skip]   images/defaults/no-category/no-category-tile@2x.png
[17:13:02] [skip]   static-images/defaults/food/food-sq.png
[17:13:02] [skip]   static-images/defaults/arts/arts-sq@3x.png
[17:13:02] [skip]   static-images/defaults/arts/arts-sq@2x.png
[17:13:02] [skip]   static-images/defaults/arts/arts-tile@2x.png
[17:13:02] [skip]   static-images/defaults/arts/arts-sq.png
[17:13:02] [skip]   static-images/defaults/arts/arts-tile@3x.png
[17:13:02] [skip]   static-images/defaults/food/food-tile.png
[17:13:02] [skip]   static-images/defaults/food/food-sq@2x.png
[17:13:02] [skip]   static-images/defaults/food/food-sq@3x.png
[17:13:02] [skip]   static-images/defaults/news/news-sq.png
[17:13:02] [skip]   static-images/defaults/food/food-tile@3x.png
[17:13:02] [skip]   static-images/defaults/news/news-sq@3x.png
[17:13:02] [skip]   static-images/defaults/food/food-tile@2x.png
[17:13:02] [skip]   static-images/defaults/news/news-tile.png
[17:13:02] [skip]   static-images/defaults/news/news-tile@2x.png
[17:13:02] [skip]   static-images/defaults/news/news-tile@3x.png
[17:13:02] [skip]   static-images/defaults/no-category/no-category-sq@2x.png
[17:13:02] [skip]   static-images/defaults/no-category/no-category-tile@2x.png
[17:13:02] [skip]   static-images/defaults/no-category/no-category-tile.png
[17:13:02] [skip]   static-images/defaults/no-category/no-category-sq.png
[17:13:02] [skip]   static-images/defaults/no-category/no-category-tile@3x.png
[17:13:02] [skip]   static-images/defaults/no-category/no-category-sq@3x.png
[17:13:02] [skip]   static-images/defaults/news/news-sq@2x.png
```
```
[17:13:02] [update] robots.txt
```
```
[17:13:05] Cloudfront invalidation created: IS1P7ODM761KU
[17:14:25] Finished 'deploy' after 1.4 min
```

</details>