### PR TITLE
Enable testing on circle ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -138,18 +138,18 @@ workflows:
           filters:
             branches:
               ignore: /main|[A-Za-z-_]+/[A-Za-z-_\d]+/
-     - test-static:
-         requires:
-           - build-static
+      - test-static:
+          requires:
+            - build-static
 
   deploy-demo:
     jobs:
       - build-static:
           <<: *filter_demo
-     - test-static:
-         <<: *filter_demo
-         requires:
-           - build-static
+      - test-static:
+          <<: *filter_demo
+          requires:
+            - build-static
       - deploy-static-demo:
           <<: *filter_demo
           requires:
@@ -163,10 +163,10 @@ workflows:
     jobs:
       - build-static:
           <<: *filter_prod
-     - test-static:
-         <<: *filter_prod
-         requires:
-           - build-static
+      - test-static:
+          <<: *filter_prod
+          requires:
+            - build-static
       - deploy-static-prod:
           <<: *filter_prod
           requires:

--- a/circle.yml
+++ b/circle.yml
@@ -137,7 +137,7 @@ workflows:
       - build-static:
           filters:
             branches:
-              ignore: /main|[A-Za-z-_]+/[A-Za-z-_\d]+/
+              ignore: main
       - test-static:
           requires:
             - build-static

--- a/circle.yml
+++ b/circle.yml
@@ -80,6 +80,7 @@ templates:
       tags:
         only: /^v[0-9]+\.[0-9]+\.[0-9]+/
 
+
 version: 2
 jobs:
   build-static:
@@ -137,18 +138,18 @@ workflows:
           filters:
             branches:
               ignore: /main|[A-Za-z-_]+/[A-Za-z-_\d]+/
-#      - test-static:
-#          requires:
-#            - build-static
+     - test-static:
+         requires:
+           - build-static
 
   deploy-demo:
     jobs:
       - build-static:
           <<: *filter_demo
-#      - test-static:
-#          <<: *filter_demo
-#          requires:
-#            - build-static
+     - test-static:
+         <<: *filter_demo
+         requires:
+           - build-static
       - deploy-static-demo:
           <<: *filter_demo
           requires:
@@ -162,10 +163,10 @@ workflows:
     jobs:
       - build-static:
           <<: *filter_prod
-#      - test-static:
-#          <<: *filter_prod
-#          requires:
-#            - build-static
+     - test-static:
+         <<: *filter_prod
+         requires:
+           - build-static
       - deploy-static-prod:
           <<: *filter_prod
           requires:


### PR DESCRIPTION
Enable testing on CircleCI

There was a filter rule that filtered out all branches named with the "dev/feature" convention. i think this was a holdover from our ember repos where we ran a qa build task for those branches instead. Since squash is handling QA builds we want to run the test workflow on all branches and not filter those ones out