### PR TITLE
GOTH-242 Override default scroll behavior

### DIFF
--- a/app/router.scrollBehavior.js
+++ b/app/router.scrollBehavior.js
@@ -1,0 +1,6 @@
+export default function (to, from, savedPosition) {
+  if (savedPosition) {
+    return savedPosition
+  }
+  return { x: 0, y: 0 }
+}


### PR DESCRIPTION
By default Nuxt will automatically scroll to the top of new pages, except when using that browsers' back/forward navigation, OR on child routes... because the article route is not at the top level of the directory tree, it's considered a child route so navigating to it is retains the current scroll position.
Nuxt provides a scrollToTop property to set to true when you want to override this behavior.
https://nuxtjs.org/docs/components-glossary/scrolltotop/
**But**, this property doesn't work. There are issues about in the nuxt project and nobody seems to know why it doesn't work.

Alternatively we can override the [default nuxt scroll behavior](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/router.scrollBehavior.js) by providing a custom scrollBehavior function https://nuxtjs.org/docs/configuration-glossary/configuration-router#scrollbehavior

The new function simply scrolls to the top unless there's a saved scroll position (i.e. from browser history based back/forward navigation). **When clicking to a new article the scroll position will always be set to the top.**  We don't use nested templates or anything so I don't think treating child routes differently makes sense as a default behavior for us. 

Looking at the code, it seems like the [default nuxt scroll behavior](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/router.scrollBehavior.js) does more stuff like handling hash navigation, but in my testing, the jump to #comments links still worked fine with this new function in place.


