### PR TITLE
GOTH-182

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -171,8 +171,13 @@ html {
 
 .ad-wrapper-outer.mod-header {
   position: relative;
+  display: flex;
   background: RGB(var(--color-background));
   width: 100%;
+  min-height: 72px;
+  @include media(">medium") {
+    min-height: 272px;
+  }
 }
 
 .ad-wrapper-inner {
@@ -197,7 +202,7 @@ div:empty + .ad-label {
 
 .ad-div.mod-break-margins {
   position: relative;
-  min-height: 270px;
+  min-height: 272px;
 }
 
 .ad-div.mod-break-margins > div {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -156,7 +156,7 @@ export default {
 
 <style lang="scss">
 html {
-  scroll-padding-top: 72px;
+  scroll-padding-top: 74px;
 }
 
 .home-page main {
@@ -176,9 +176,9 @@ html {
   display: flex;
   background: RGB(var(--color-background));
   width: 100%;
-  min-height: 72px;
+  min-height: 74px;
   @include media(">medium") {
-    min-height: 272px;
+    min-height: 274px;
   }
 }
 
@@ -204,7 +204,7 @@ div:empty + .ad-label {
 
 .ad-div.mod-break-margins {
   position: relative;
-  min-height: 272px;
+  min-height: 274px;
 }
 
 .ad-div.mod-break-margins > div {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,10 +5,12 @@
       class="htlad-skin"
     />
     <div
-      v-if="!isSensitiveContent && !isGallery"
       class="ad-wrapper-outer mod-header u-color-group-dark no-print"
     >
-      <div class="ad-wrapper-inner">
+      <div
+        v-if="!isSensitiveContent && !isGallery"
+        class="ad-wrapper-inner"
+      >
         <div
           v-if="isHomepage"
           key="index-leaderboard"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -197,7 +197,7 @@ html {
 }
 
 div:empty + .ad-label {
-  display: none;
+  visibility: hidden;
 }
 
 .ad-div.mod-break-margins {


### PR DESCRIPTION
Adds a min height to the header ad well as a few other tweaks (e.g. reserving space for the ad label as well) to ensure that a fixed space is reserved for it to avoid layout shift.

Tweaks the inline banners to be slightly more generous with their minimum height as well just in case