### PR TITLE
added redirect for failing tag page

### DIFF
--- a/middleware/redirects.js
+++ b/middleware/redirects.js
@@ -1,6 +1,7 @@
 const redirects =
   [
     { from: '/tags/wethecommuters', to: '/tags/we-the-commuters' },
+    { from: '/tags/agata%26valentia', to: '/tags/agata-valentia' },
     { from: '/tags/Sets%20&%20the%20City%20profile', to: '/tags/sets-and-the-city-profile' }
   ]
 


### PR DESCRIPTION
for https://nypublicradio-digital.atlassian.net/browse/GOTH-241 - sentry found a failing tag page due to the CMS user adding an ampersand in the tag name. This adds a redirect to deal with this specific tag name. 