### PR TITLE
resolved, time to review with Kim

### DIFF
--- a/components/GothamistHeader.vue
+++ b/components/GothamistHeader.vue
@@ -272,6 +272,12 @@ export default {
   width: 100%;
 }
 
+.gothamist-header.is-stuck .c-main-header__right .search-bar-form-wrapper {
+  position: fixed;
+  top: 12px;
+  right: 16px !important;
+}
+
 .progress-bar {
   position: absolute;
   width: 100%;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -164,7 +164,7 @@ export default {
 
 <style lang="scss">
 html {
-  scroll-padding-top: 74px;
+  scroll-padding-top: 85px;
 }
 
 .home-page main {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6612,12 +6612,12 @@
       }
     },
     "@nuxt/kit": {
-      "version": "npm:@nuxt/kit-edge@3.0.0-27366343.1d741cb",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit-edge/-/kit-edge-3.0.0-27366343.1d741cb.tgz",
-      "integrity": "sha512-7R9f5xoH+8gLiGSeVyKVpEPwqdbptoJ1X852gbGSMEATLb7Wc0eDVUj4/PTBMSjvYuNm54a0bGO0OG02nXZViw==",
+      "version": "npm:@nuxt/kit-edge@3.0.0-27368185.a4f300b",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit-edge/-/kit-edge-3.0.0-27368185.a4f300b.tgz",
+      "integrity": "sha512-UFN5EUbCnxbNh7aRL6AV6lYMrv9mo1X8mgV5doXiewZi0m/sydOCkffLGtRSYLm63fO4K0AfkJd1J05kXXB62Q==",
       "dev": true,
       "requires": {
-        "@nuxt/schema": "npm:@nuxt/schema-edge@3.0.0-27366343.1d741cb",
+        "@nuxt/schema": "npm:@nuxt/schema-edge@3.0.0-27368185.a4f300b",
         "consola": "^2.15.3",
         "defu": "^5.0.0",
         "dotenv": "^11.0.0",
@@ -6636,9 +6636,9 @@
       },
       "dependencies": {
         "@nuxt/schema": {
-          "version": "npm:@nuxt/schema-edge@3.0.0-27366343.1d741cb",
-          "resolved": "https://registry.npmjs.org/@nuxt/schema-edge/-/schema-edge-3.0.0-27366343.1d741cb.tgz",
-          "integrity": "sha512-u3EFLXiisctQlKFLEsuVYxdZroO7FnrMZV1uAOHUbgyX4/0oakhCeFbKko754HaD4wgawFHIPZ2YDJGi1eTO5g==",
+          "version": "npm:@nuxt/schema-edge@3.0.0-27368185.a4f300b",
+          "resolved": "https://registry.npmjs.org/@nuxt/schema-edge/-/schema-edge-3.0.0-27368185.a4f300b.tgz",
+          "integrity": "sha512-8sUsjGNKq957wS9yKzCB0zBv9B9uSKIhmHDFLpDV/2sTl3N5q9sFMaRtOgFEgwDVAcO882h0xOOwgHaHuUG3Iw==",
           "dev": true,
           "requires": {
             "create-require": "^1.1.1",
@@ -6719,16 +6719,16 @@
       }
     },
     "@nuxt/nitro": {
-      "version": "npm:@nuxt/nitro-edge@3.0.0-27366343.1d741cb",
-      "resolved": "https://registry.npmjs.org/@nuxt/nitro-edge/-/nitro-edge-3.0.0-27366343.1d741cb.tgz",
-      "integrity": "sha512-AB+hN0hBpLP9Twad7ovQEcty82TrHkT2wBapPB0XUlg/x5LiqlPLKymfSn9nHsHb2f8ZI/OL01+k7CDG/XLvCQ==",
+      "version": "npm:@nuxt/nitro-edge@3.0.0-27368185.a4f300b",
+      "resolved": "https://registry.npmjs.org/@nuxt/nitro-edge/-/nitro-edge-3.0.0-27368185.a4f300b.tgz",
+      "integrity": "sha512-W3fg+WEtW280dhaxkesQGPCMBB2bkoiYF2QltxHMpBVkPCfG2i37H0qfBfiUYGSqQ70oZTe8jBbeuXRKf/omog==",
       "dev": true,
       "requires": {
         "@cloudflare/kv-asset-handler": "^0.2.0",
         "@netlify/functions": "^0.10.0",
         "@nuxt/design": "0.1.5",
         "@nuxt/devalue": "^2.0.0",
-        "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27366343.1d741cb",
+        "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27368185.a4f300b",
         "@rollup/plugin-alias": "^3.1.9",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-inject": "^4.0.4",
@@ -6779,7 +6779,7 @@
         "ufo": "^0.7.9",
         "unenv": "^0.4.3",
         "unstorage": "^0.3.3",
-        "vue-bundle-renderer": "^0.3.4",
+        "vue-bundle-renderer": "^0.3.5",
         "vue-server-renderer": "^2.6.14"
       },
       "dependencies": {
@@ -6822,9 +6822,9 @@
           }
         },
         "@vercel/nft": {
-          "version": "0.17.2",
-          "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.17.2.tgz",
-          "integrity": "sha512-1ueYh62H/DmUc3PWV/HEk1x6J1c/KZq9zeNXhixn/C4lX3XOsouutUVpKhTseoDKTGlT81hx96W4TjIwpDiIAQ==",
+          "version": "0.17.3",
+          "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.17.3.tgz",
+          "integrity": "sha512-fdGzXF8dVrHliAzk4p2TOfG78K7MgWleDZ0+ztDQe6TdBw31c3S6Fvg6rdcV8g4Y20HTFtPzKua3uj3PGRagZg==",
           "dev": true,
           "requires": {
             "@mapbox/node-pre-gyp": "^1.0.5",
@@ -6834,7 +6834,6 @@
             "glob": "^7.1.3",
             "graceful-fs": "^4.2.9",
             "micromatch": "^4.0.2",
-            "mkdirp": "^0.5.1",
             "node-gyp-build": "^4.2.2",
             "node-pre-gyp": "^0.13.0",
             "resolve-from": "^5.0.0",
@@ -7236,6 +7235,15 @@
             "slice-ansi": "^4.0.0",
             "string-width": "^4.2.3",
             "strip-ansi": "^6.0.1"
+          }
+        },
+        "vue-bundle-renderer": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/vue-bundle-renderer/-/vue-bundle-renderer-0.3.5.tgz",
+          "integrity": "sha512-LmiGFvlK3ZVtUklpJKVmVkJcmpkLEHKE9YbSR6WgFULIikw3pusXhX3vZPkL9tGcjzBERVrB9CQYDGdWApnEJQ==",
+          "dev": true,
+          "requires": {
+            "bundle-runner": "^0.0.1"
           }
         }
       }
@@ -7688,12 +7696,12 @@
       }
     },
     "@nuxt/vite-builder": {
-      "version": "npm:@nuxt/vite-builder-edge@3.0.0-27366343.1d741cb",
-      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder-edge/-/vite-builder-edge-3.0.0-27366343.1d741cb.tgz",
-      "integrity": "sha512-t9cRkKpv2xltPIfXV0nmEzA6qXmnUq0eTAP4i0MZ0HrBsr+C9uP2eNZZbTNBH5wdx5Qpxg3zqG7GgrgZZJaXSg==",
+      "version": "npm:@nuxt/vite-builder-edge@3.0.0-27368185.a4f300b",
+      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder-edge/-/vite-builder-edge-3.0.0-27368185.a4f300b.tgz",
+      "integrity": "sha512-dDhfGjwwmzU2qUt2Wu+Y1N9hSvVCM1YW9rlR14WtNQXMUHvrhhlqCUIyhcwLPw1uv2RW8eXKbFelOynEpZMtkw==",
       "dev": true,
       "requires": {
-        "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27366343.1d741cb",
+        "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27368185.a4f300b",
         "@vitejs/plugin-vue": "^2.0.1",
         "@vitejs/plugin-vue-jsx": "^1.3.3",
         "autoprefixer": "^10.4.2",
@@ -7712,7 +7720,7 @@
         "postcss-url": "^10.1.3",
         "rollup-plugin-visualizer": "^5.5.2",
         "ufo": "^0.7.9",
-        "vite": "^2.7.10"
+        "vite": "2.7.10"
       },
       "dependencies": {
         "anymatch": {
@@ -7781,9 +7789,9 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.4.44",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.44.tgz",
-          "integrity": "sha512-tHGWiUUmY7GABK8+DNcr474cnZDTzD8x1736SlDosVH8+/vRJeqfaIBAEHFtMjddz/0T4rKKYsxEc8BwQRdBpw==",
+          "version": "1.4.45",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.45.tgz",
+          "integrity": "sha512-czF9eYVuOmlY/vxyMQz2rGlNSjZpxNQYBe1gmQv7al171qOIhgyO9k7D5AKlgeTCSPKk+LHhj5ZyIdmEub9oNg==",
           "dev": true
         },
         "esbuild": {
@@ -8230,14 +8238,14 @@
       }
     },
     "@nuxt/webpack-builder": {
-      "version": "npm:@nuxt/webpack-builder-edge@3.0.0-27366343.1d741cb",
-      "resolved": "https://registry.npmjs.org/@nuxt/webpack-builder-edge/-/webpack-builder-edge-3.0.0-27366343.1d741cb.tgz",
-      "integrity": "sha512-Ti52LTGjbLQxQ43zgOLJ6ZX9t+OlUz1yHrbaF7SUZiszqLWDGuOVOftnF42nFlRKYfFv7q2KyTJM7zIM1577bg==",
+      "version": "npm:@nuxt/webpack-builder-edge@3.0.0-27368185.a4f300b",
+      "resolved": "https://registry.npmjs.org/@nuxt/webpack-builder-edge/-/webpack-builder-edge-3.0.0-27368185.a4f300b.tgz",
+      "integrity": "sha512-IbHC3bNOHM8BOXOHa5b1Sb1Jo0kouqlGS5NrqLxnqmVmCgvhqdCy7WJvvqtYYdIdr2b2jV03QMBq1UQY+vf56w==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.16.7",
         "@nuxt/friendly-errors-webpack-plugin": "^2.5.2",
-        "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27366343.1d741cb",
+        "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27368185.a4f300b",
         "@vue/babel-preset-jsx": "^1.2.4",
         "autoprefixer": "^10.4.2",
         "babel-loader": "^8.2.3",
@@ -8267,7 +8275,7 @@
         "url-loader": "^4.1.1",
         "vue-loader": "^17.0.0",
         "vue-style-loader": "^4.1.3",
-        "webpack": "^5.65.0",
+        "webpack": "^5.66.0",
         "webpack-bundle-analyzer": "^4.5.0",
         "webpack-dev-middleware": "^5.3.0",
         "webpack-hot-middleware": "^2.25.1",
@@ -8876,9 +8884,9 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.4.44",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.44.tgz",
-          "integrity": "sha512-tHGWiUUmY7GABK8+DNcr474cnZDTzD8x1736SlDosVH8+/vRJeqfaIBAEHFtMjddz/0T4rKKYsxEc8BwQRdBpw==",
+          "version": "1.4.45",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.45.tgz",
+          "integrity": "sha512-czF9eYVuOmlY/vxyMQz2rGlNSjZpxNQYBe1gmQv7al171qOIhgyO9k7D5AKlgeTCSPKk+LHhj5ZyIdmEub9oNg==",
           "dev": true
         },
         "enhanced-resolve": {
@@ -11475,9 +11483,9 @@
           "dev": true
         },
         "ws": {
-          "version": "8.4.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-          "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+          "version": "8.4.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.1.tgz",
+          "integrity": "sha512-6eqQ4yN2y2xv8b+BgbkUzPPyfo/PDl3VOWb06ZE0jIFYwuHMsMQN6F7o84yxJYCblfCRAxzpU59We4Rr4w0Luw==",
           "dev": true
         }
       }
@@ -26546,9 +26554,9 @@
       }
     },
     "mini-css-extract-plugin": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.4.6.tgz",
-      "integrity": "sha512-khHpc29bdsE9EQiGSLqQieLyMbGca+bkC42/BBL1gXC8yAS0nHpOTUCBYUK6En1FuRdfE9wKXhGtsab8vmsugg==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.4.7.tgz",
+      "integrity": "sha512-euWmddf0sk9Nv1O0gfeeUAvAkoSlWncNLF77C0TP2+WoPvy8mAHKOzMajcCz2dzvyt3CNgxb1obIEVFIRxaipg==",
       "dev": true,
       "requires": {
         "schema-utils": "^4.0.0"
@@ -27594,9 +27602,9 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nuxi": {
-      "version": "npm:nuxi-edge@3.0.0-27366343.1d741cb",
-      "resolved": "https://registry.npmjs.org/nuxi-edge/-/nuxi-edge-3.0.0-27366343.1d741cb.tgz",
-      "integrity": "sha512-jiO5mK8SQp6DoELJKLg3yK9ppP32Q2707JaHOCOS2h1Vu6x1cZS6ohMB8/Zh2GRIX22BmM2TQOSQNR7ba9LRFg==",
+      "version": "npm:nuxi-edge@3.0.0-27368185.a4f300b",
+      "resolved": "https://registry.npmjs.org/nuxi-edge/-/nuxi-edge-3.0.0-27368185.a4f300b.tgz",
+      "integrity": "sha512-dFnvKsFEUSu8Gea6lqY2grjmALHpkQNF2US0W+Ywx9SdT0GAVrwcUJxZxeCyfA60ekRnxCck6czI705kkf26HA==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -27640,8 +27648,8 @@
       "dev": true
     },
     "nypr-design-system-vue": {
-      "version": "github:nypublicradio/nypr-design-system-vue#e283958ad3bc62736b6e8f7769d2cf3114850fe3",
-      "from": "github:nypublicradio/nypr-design-system-vue#e283958ad3bc62736b6e8f7769d2cf3114850fe3",
+      "version": "github:nypublicradio/nypr-design-system-vue#3f2d67b78351e3cef959764f9d1e60a2d2b7cdf4",
+      "from": "github:nypublicradio/nypr-design-system-vue#3f2d67b78351e3cef959764f9d1e60a2d2b7cdf4",
       "dev": true,
       "requires": {
         "@babel/preset-env": "^7.16.7",
@@ -27738,9 +27746,9 @@
           }
         },
         "@nuxt/schema": {
-          "version": "npm:@nuxt/schema-edge@3.0.0-27366343.1d741cb",
-          "resolved": "https://registry.npmjs.org/@nuxt/schema-edge/-/schema-edge-3.0.0-27366343.1d741cb.tgz",
-          "integrity": "sha512-u3EFLXiisctQlKFLEsuVYxdZroO7FnrMZV1uAOHUbgyX4/0oakhCeFbKko754HaD4wgawFHIPZ2YDJGi1eTO5g==",
+          "version": "npm:@nuxt/schema-edge@3.0.0-27368185.a4f300b",
+          "resolved": "https://registry.npmjs.org/@nuxt/schema-edge/-/schema-edge-3.0.0-27368185.a4f300b.tgz",
+          "integrity": "sha512-8sUsjGNKq957wS9yKzCB0zBv9B9uSKIhmHDFLpDV/2sTl3N5q9sFMaRtOgFEgwDVAcO882h0xOOwgHaHuUG3Iw==",
           "dev": true,
           "requires": {
             "create-require": "^1.1.1",
@@ -28160,17 +28168,17 @@
           "dev": true
         },
         "nuxt3": {
-          "version": "3.0.0-27366343.1d741cb",
-          "resolved": "https://registry.npmjs.org/nuxt3/-/nuxt3-3.0.0-27366343.1d741cb.tgz",
-          "integrity": "sha512-zDYnxNd9ucz0yvprP5MLn3IgoWPkM6ksb6N/L2XIswSVohqZUsNJlxQ1crhga5fAMi/do+P0rLN9biPLcofXoA==",
+          "version": "3.0.0-27368185.a4f300b",
+          "resolved": "https://registry.npmjs.org/nuxt3/-/nuxt3-3.0.0-27368185.a4f300b.tgz",
+          "integrity": "sha512-d3WedMVE7KfPM0xnICpHGxHIvehM+iU2iFToq1cPb1JLkRCHieRcbfehirXnja10SJIHmDWNTPNIOFaiNCa5yw==",
           "dev": true,
           "requires": {
             "@nuxt/design": "^0.1.5",
-            "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27366343.1d741cb",
-            "@nuxt/nitro": "npm:@nuxt/nitro-edge@3.0.0-27366343.1d741cb",
-            "@nuxt/schema": "npm:@nuxt/schema-edge@3.0.0-27366343.1d741cb",
-            "@nuxt/vite-builder": "npm:@nuxt/vite-builder-edge@3.0.0-27366343.1d741cb",
-            "@nuxt/webpack-builder": "npm:@nuxt/webpack-builder-edge@3.0.0-27366343.1d741cb",
+            "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27368185.a4f300b",
+            "@nuxt/nitro": "npm:@nuxt/nitro-edge@3.0.0-27368185.a4f300b",
+            "@nuxt/schema": "npm:@nuxt/schema-edge@3.0.0-27368185.a4f300b",
+            "@nuxt/vite-builder": "npm:@nuxt/vite-builder-edge@3.0.0-27368185.a4f300b",
+            "@nuxt/webpack-builder": "npm:@nuxt/webpack-builder-edge@3.0.0-27368185.a4f300b",
             "@vue/reactivity": "^3.2.26",
             "@vue/shared": "^3.2.26",
             "@vueuse/head": "^0.7.4",
@@ -28186,7 +28194,7 @@
             "ignore": "^5.2.0",
             "mlly": "^0.3.17",
             "murmurhash-es": "^0.1.1",
-            "nuxi": "npm:nuxi-edge@3.0.0-27366343.1d741cb",
+            "nuxi": "npm:nuxi-edge@3.0.0-27368185.a4f300b",
             "ohmyfetch": "^0.4.14",
             "pathe": "^0.2.0",
             "scule": "^0.2.1",
@@ -31427,9 +31435,9 @@
       "dev": true
     },
     "regexp.prototype.flags": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.2.tgz",
+      "integrity": "sha512-uaro52GSI5be7+ssxjxxnLlleDBN3VHIWQHvBhfeeSXRQkuV/0Jo/hBU+omYH6NUkM+LYpTHnRRf2W/v+x7LzQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "jest-axe": "^5.0.1",
     "jest-junit": "^13.0.0",
     "node-sass": "^4.14.1",
-    "nypr-design-system-vue": "github:nypublicradio/nypr-design-system-vue#e283958ad3bc62736b6e8f7769d2cf3114850fe3",
+    "nypr-design-system-vue": "github:nypublicradio/nypr-design-system-vue#3f2d67b78351e3cef959764f9d1e60a2d2b7cdf4",
     "sass-loader": "^10.1.1",
     "ufo": "^0.7.9",
     "vue": "^2.6.14",


### PR DESCRIPTION
this description is the same on the DS PR:

This one is a tricky one. I will need to explain over a zoom call. 
But in a nut shell. html { scroll-padding-top: 85px; } is the issue in the default.vue and a small update in the component. 

In the DS,  VSearch.vue, I just updated the focus() to this: "this.$refs.searchInput.focus({ preventScroll: true })". This stopped the scrolling when initially clicking on the search icon and getting focus on the text field.


The reason tying in the text field scrolls the site is because it is trying to get the text field into the view port, which is currently set to be 85px ( html { scroll-padding-top: 85px; } ) from the top. But because the text field in in the sticky header, it never reaches the specified viewport. To prevent this, you have to make something around the search input to be position:fixed. So, I added the following in GothamistHeaader.vue:

.gothamist-header.is-stuck .c-main-header__right .search-bar-form-wrapper {
  position: fixed;
  top: 12px;
  right: 16px !important;
}

This css makes the search bar position fixed with the ".is-stuck" is added by the "v-observe-visibility". It works well, except for one small instance on the home page... when .is-stuck is applied a little early, and the search field is not positioned properly. Maybe you (kim) can explain more on how the "v-observe-visibility" is working better, and maybe I can resolve that small issue.