### PR TITLE
GOTH-233 SFMC Cookies/Analytics

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -146,8 +146,9 @@ export default {
 
     // load these after all other plugins (including dynamically loaded plugins from modules)
     // instead of loading them from the plugins array
+    plugins.push('~/plugins/sfmc-analytics.client.js')
     plugins.push('~/plugins/google-optimize-analytics.client.js')
-    plugins.push('~/plugins/features')
+    plugins.push('~/plugins/features.js')
     return plugins
   },
 

--- a/plugins/features.js
+++ b/plugins/features.js
@@ -16,6 +16,6 @@ export default function ({ $exp }, inject) {
     disabled[feature[0]] = !feature[1]
   }
   const classes = Object.entries(enabled)
-    .map((entry) => (entry[1] ? `${entry[0]}-enabled` : `${entry[0]}-disabled`))
+    .map(entry => (entry[1] ? `${entry[0]}-enabled` : `${entry[0]}-disabled`))
   inject('features', { enabled, disabled, classes })
 }

--- a/plugins/sfmc-analytics.client.js
+++ b/plugins/sfmc-analytics.client.js
@@ -1,6 +1,7 @@
 export default ({ $gtm, $cookies }) => {
   const setActiveMember = function () {
-    $cookies.set('_gothamistNyprMember', 'True')
+    const maxAge = 60 * 60 * 24 * 365 * 5 // 5 years, the far future
+    $cookies.set('_gothamistNyprMember', 'True', { path: '/', maxAge })
     $gtm.push({ NYPRMember: 'active-member' })
   }
 

--- a/plugins/sfmc-analytics.client.js
+++ b/plugins/sfmc-analytics.client.js
@@ -1,12 +1,15 @@
 export default ({ $gtm, $cookies }) => {
+  const maxAge = 60 * 60 * 24 * 365 * 5 // 5 years, the far future
+
+  // Set the cookie and data layer status for an active member
   const setActiveMember = function () {
-    const maxAge = 60 * 60 * 24 * 365 * 5 // 5 years, the far future
     $cookies.set('_gothamistNyprMember', 'True', { path: '/', maxAge })
     $gtm.push({ NYPRMember: 'active-member' })
   }
 
+  // Set the cookie and data layer status for an inactive member
   const setInactiveMember = function () {
-    $cookies.set('_gothamistNyprMember', 'False')
+    $cookies.set('_gothamistNyprMember', 'False', { path: '/', maxAge })
     $gtm.push({ NYPRMember: 'inactive-member' })
   }
 
@@ -20,6 +23,7 @@ export default ({ $gtm, $cookies }) => {
       case 'False':
         setInactiveMember()
         return // if setting status from url, we don't need to check cookie
+      default:
     }
   }
 
@@ -30,5 +34,6 @@ export default ({ $gtm, $cookies }) => {
     case 'False':
       setInactiveMember()
       break
+    default:
   }
 }

--- a/plugins/sfmc-analytics.client.js
+++ b/plugins/sfmc-analytics.client.js
@@ -14,6 +14,11 @@ export default ({ $gtm, $cookies }) => {
     $gtm.push({ NYPRMember: 'inactive-member' })
   }
 
+  // Set the data layer status for an unknown membership status (no cookie)
+  const setUnknownStatus = function () {
+    $gtm.push({ NYPRMember: 'status-unknown' })
+  }
+
   if (window && window.location) {
     const url = new URL(window.location.href)
     const memberStatus = url.searchParams.get('nypr_member')
@@ -25,6 +30,7 @@ export default ({ $gtm, $cookies }) => {
         setInactiveMember()
         return // if setting status from url, we don't need to check cookie
       default:
+        setUnknownStatus()
     }
   }
 
@@ -36,5 +42,6 @@ export default ({ $gtm, $cookies }) => {
       setInactiveMember()
       break
     default:
+      setUnknownStatus()
   }
 }

--- a/plugins/sfmc-analytics.client.js
+++ b/plugins/sfmc-analytics.client.js
@@ -1,5 +1,5 @@
 export default ({ $gtm, $cookies }) => {
-  const maxAge = 60 * 60 * 24 * 365 * 5 // 5 years, the far future
+  const maxAge = 60 * 60 * 24 * 30 * 6 // about 6 months
 
   // Set the cookie and data layer status for an active member
   const setActiveMember = function () {

--- a/plugins/sfmc-analytics.client.js
+++ b/plugins/sfmc-analytics.client.js
@@ -1,0 +1,33 @@
+export default ({ $gtm, $cookies }) => {
+  const setActiveMember = function () {
+    $cookies.set('_gothamistNyprMember', 'True')
+    $gtm.push({ NYPRMember: 'active-member' })
+  }
+
+  const setInactiveMember = function () {
+    $cookies.set('_gothamistNyprMember', 'False')
+    $gtm.push({ NYPRMember: 'inactive-member' })
+  }
+
+  if (window && window.location) {
+    const url = new URL(window.location.href)
+    const memberStatus = url.searchParams.get('nypr_member')
+    switch (memberStatus) {
+      case 'True':
+        setActiveMember()
+        return // if setting status from url, we don't need to check cookie
+      case 'False':
+        setInactiveMember()
+        return // if setting status from url, we don't need to check cookie
+    }
+  }
+
+  switch ($cookies.get('_gothamistNyprMember')) {
+    case 'True':
+      setActiveMember()
+      break
+    case 'False':
+      setInactiveMember()
+      break
+  }
+}

--- a/plugins/sfmc-analytics.client.js
+++ b/plugins/sfmc-analytics.client.js
@@ -1,15 +1,16 @@
 export default ({ $gtm, $cookies }) => {
+  const memberStatusCookie = '_gothamistNyprMember'
   const maxAge = 60 * 60 * 24 * 30 * 6 // about 6 months
 
   // Set the cookie and data layer status for an active member
   const setActiveMember = function () {
-    $cookies.set('_gothamistNyprMember', 'True', { path: '/', maxAge })
+    $cookies.set(memberStatusCookie, 'True', { path: '/', maxAge })
     $gtm.push({ NYPRMember: 'active-member' })
   }
 
   // Set the cookie and data layer status for an inactive member
   const setInactiveMember = function () {
-    $cookies.set('_gothamistNyprMember', 'False', { path: '/', maxAge })
+    $cookies.set(memberStatusCookie, 'False', { path: '/', maxAge })
     $gtm.push({ NYPRMember: 'inactive-member' })
   }
 
@@ -27,7 +28,7 @@ export default ({ $gtm, $cookies }) => {
     }
   }
 
-  switch ($cookies.get('_gothamistNyprMember')) {
+  switch ($cookies.get(memberStatusCookie)) {
     case 'True':
       setActiveMember()
       break

--- a/store/global.js
+++ b/store/global.js
@@ -114,7 +114,7 @@ export const actions = {
       })
       .catch((error) => {
         // eslint-disable-next-line no-console
-        
+        console.warn('Error Loading Navigation', error)
       })
   }
 }


### PR DESCRIPTION
https://nypublicradio-digital.atlassian.net/browse/GOTH-233
- Added a new custom dimension (11) and data layer variable (`NYPRMember`) to our GTM config
- This adds a nuxt plugin that checks for the sfmc query param, or a cookie with membership status. If either exists it pushes that value to the GTM data layer and updates the cookie.