### PR TITLE
Update deploy setup for more consistent builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
           command: |
             env | sed -n "s/^${ENV^^}_//p" >> .env
             set -o allexport && source .env && set +o allexport
-            npm install
+            npm ci
             npm run deploy
 
   deploy-nuxt:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,9 @@ RUN apt-get update \
 WORKDIR /code
 
 COPY package.json ./
+COPY ./package-lock.json ./
 
-RUN npm install 
+RUN npm ci
 
 COPY . ./
 RUN rm /etc/nginx/nginx.conf \


### PR DESCRIPTION
May or may not help with the current deployment issues, but it's something we should be doing anyway.

Always using a lockfile helps ensure our builds are consistent across different environments and days of the week.