### PR TITLE
Disables ecs exec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,8 +186,7 @@ jobs:
               --ports=80 \
               --environment=$ENV \
               --tag=$TAG \
-              --wait=300 \
-              --enable-execute-command 
+              --wait=300
       - save_cache:
           <<: *circle_key
           paths: 


### PR DESCRIPTION
I noticed this flag was present, probably forgotten from some time when we needed SSH access to the cluster. Removing it now for security hygiene.