### PR TITLE
Replace comments with beta opt in

### DIFF
--- a/components/BetaOptIn.vue
+++ b/components/BetaOptIn.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="beta-opt-in">
+    A new Gothamist is coming! We’ve moved comments over to our beta site. <a :href="`beta-opt-in/${redirectTo ? '?target=' + redirectTo : ''} `">Click here to join the conversation and get a preview of our new website.</a>
+  </div>
+</template>
+<script>
+export default {
+  name: 'BetaOptIn',
+  props: {
+    redirectTo: {
+      type: String,
+      default: ''
+    }
+  }
+}
+</script>
+<style lang="scss">
+.beta-opt-in {
+  background-color: RGB(var(--color-background-standard));
+  border: 3px solid RGB(var(--color-border-standard));
+  padding: var(--space-5) var(--space-4);
+  margin-bottom: var(--space-6);
+}
+
+.beta-opt-in a {
+  text-decoration: underline;
+    text-decoration: var(--text-decoration-link);
+    text-underline-position: under;
+    border-bottom: none;
+    cursor: pointer;
+    padding-bottom: 2px;
+    border-bottom: 2px dotted RGB(var(--color-link));
+    text-decoration: none;
+    color: RGB(var(--color-link));
+
+    &:hover {
+      color: RGB(var(--color-link-hover));
+      background-color: RGB(var(--color-reddish-orange));
+    }
+}
+</style>

--- a/components/GothamistArticle.vue
+++ b/components/GothamistArticle.vue
@@ -182,16 +182,9 @@
           intersection: { rootMargin: '300px 0px 0px 0px', threshold: 0.01 }
         }"
       />
-      <template v-if="!article.disableComments && showComments">
-        <disqus-embed
-          v-if="article"
-          :identifier="String(article.legacyId || article.uuid)"
-          :url="article.url"
-          @new-comment="handleNewComment"
-        />
-        <v-spacer size="quin" />
-      </template>
-
+      <div class="l-container l-container--10col">
+        <beta-opt-in :redirect-to="this.$route.path" />
+      </div>
       <dismissible-area prefix="donateBanner" :views-before-showable="2">
         <template v-slot="dismissibleArea">
           <donate-banner

--- a/pages/beta-opt-in.vue
+++ b/pages/beta-opt-in.vue
@@ -1,0 +1,14 @@
+<template>
+  <div />
+</template>
+
+<script>
+export default {
+  beforeMount () {
+    const targetPath = 'https://gothamist.com' + this.$route.query.target || ''
+    const oneMonth = 60 * 60 * 24 * 31
+    this.$cookies.set('betaLot', '1', { path: '/', maxAge: oneMonth })
+    window.location.href = targetPath
+  }
+}
+</script>

--- a/pages/beta-opt-in.vue
+++ b/pages/beta-opt-in.vue
@@ -5,7 +5,7 @@
 <script>
 export default {
   beforeMount () {
-    const targetPath = 'https://gothamist.com' + this.$route.query.target || ''
+    const targetPath = `https://gothamist.com${this.$route.query.target || ''}`
     const cookieOptions = {
       secure: true,
       httpOnly: true,

--- a/pages/beta-opt-in.vue
+++ b/pages/beta-opt-in.vue
@@ -6,8 +6,12 @@
 export default {
   beforeMount () {
     const targetPath = 'https://gothamist.com' + this.$route.query.target || ''
-    const oneMonth = 60 * 60 * 24 * 31
-    this.$cookies.set('betaLot', '1', { path: '/', maxAge: oneMonth })
+    const cookieOptions = {
+      secure: true,
+      httpOnly: true,
+      expires: 'Thu, 01 Dec 2022 05:00:00 GMT'
+    }
+    this.$cookies.set('betaLot', '1', cookieOptions)
     window.location.href = targetPath
   }
 }


### PR DESCRIPTION
- Add a route that sets the beta cookie and redirects you back to the site. Cloudfront should hand the rest.
- Adds a bet opt in module that takes you to the opt-in route
- Replaces the comment section with said module